### PR TITLE
Added birthday priority to puzzles

### DIFF
--- a/puzzles/2023-05-09.json
+++ b/puzzles/2023-05-09.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 19292,
-  "target_tvdb_id": 1003,
-  "source_imdb_id": "nm0001191",
-  "target_imdb_id": "nm0000606",
+  "source_tvdb_id": 13240,
+  "target_tvdb_id": 585902,
+  "source_imdb_id": "nm0000242",
+  "target_imdb_id": "nm0032370",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0001191",
       "type": "Actor",
-      "name": "Adam Sandler",
-      "tvdb_id": 19292
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0762107",
-      "votes": 150279,
-      "rating": 5.9,
-      "name": "I Now Pronounce You Chuck & Larry",
-      "tvdb_id": 3563
+      "imdb_id": "tt0380510",
+      "votes": 173509,
+      "rating": 6.6,
+      "name": "The Lovely Bones",
+      "tvdb_id": 7980
     },
     {
-      "imdb_id": "nm0000609",
       "type": "Actor",
-      "name": "Ving Rhames",
-      "tvdb_id": 10182
+      "imdb_id": "nm0680273",
+      "tvdb_id": null,
+      "name": "Bruce Phillips"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0117060",
-      "votes": 437118,
-      "rating": 7.1,
-      "name": "Mission: Impossible",
-      "tvdb_id": 954
+      "imdb_id": "tt0167260",
+      "votes": 1880701,
+      "rating": 9.0,
+      "name": "The Lord of the Rings: The Return of the King",
+      "tvdb_id": 122
     },
     {
-      "imdb_id": "nm0000606",
       "type": "Actor",
-      "name": "Jean Reno",
-      "tvdb_id": 1003
+      "imdb_id": "nm0032370",
+      "tvdb_id": 585902,
+      "name": "Noel Appleby"
     }
   ]
 }

--- a/puzzles/2023-05-10.json
+++ b/puzzles/2023-05-10.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5472,
-  "target_tvdb_id": 6161,
-  "source_imdb_id": "nm0000147",
-  "target_imdb_id": "nm0000124",
+  "source_tvdb_id": 3131,
+  "target_tvdb_id": 62064,
+  "source_imdb_id": "nm0000104",
+  "target_imdb_id": "nm1517976",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000147",
       "type": "Actor",
-      "name": "Colin Firth",
-      "tvdb_id": 5472
+      "imdb_id": "nm0000104",
+      "tvdb_id": 3131,
+      "name": "Antonio Banderas"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1504320",
-      "votes": 690511,
-      "rating": 8.0,
-      "name": "The King's Speech",
-      "tvdb_id": 45269
+      "imdb_id": "tt1189073",
+      "votes": 157715,
+      "rating": 7.6,
+      "name": "The Skin I Live In",
+      "tvdb_id": 63311
     },
     {
-      "imdb_id": "nm1994157",
       "type": "Actor",
-      "name": "Julie Eagleton",
-      "tvdb_id": null
+      "imdb_id": "nm0025745",
+      "tvdb_id": 3623,
+      "name": "Elena Anaya"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0450259",
-      "votes": 562068,
-      "rating": 8.0,
-      "name": "Blood Diamond",
-      "tvdb_id": 1372
+      "imdb_id": "tt0451279",
+      "votes": 672170,
+      "rating": 7.4,
+      "name": "Wonder Woman",
+      "tvdb_id": 297762
     },
     {
-      "imdb_id": "nm0000124",
       "type": "Actor",
-      "name": "Jennifer Connelly",
-      "tvdb_id": 6161
+      "imdb_id": "nm1517976",
+      "tvdb_id": 62064,
+      "name": "Chris Pine"
     }
   ]
 }

--- a/puzzles/2023-05-11.json
+++ b/puzzles/2023-05-11.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4483,
-  "target_tvdb_id": 1328,
-  "source_imdb_id": "nm0000163",
-  "target_imdb_id": "nm0000276",
+  "source_tvdb_id": 21007,
+  "target_tvdb_id": 27578,
+  "source_imdb_id": "nm1706767",
+  "target_imdb_id": "nm0680983",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000163",
       "type": "Actor",
-      "name": "Dustin Hoffman",
-      "tvdb_id": 4483
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2883512",
-      "votes": 221829,
-      "rating": 7.3,
-      "name": "Chef",
-      "tvdb_id": 212778
+      "imdb_id": "tt0993846",
+      "votes": 1455112,
+      "rating": 8.2,
+      "name": "The Wolf of Wall Street",
+      "tvdb_id": 106646
     },
     {
-      "imdb_id": "nm0269463",
       "type": "Actor",
-      "name": "Jon Favreau",
-      "tvdb_id": 15277
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0108002",
-      "votes": 65853,
-      "rating": 7.5,
-      "name": "Rudy",
-      "tvdb_id": 14534
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
     },
     {
-      "imdb_id": "nm0000276",
       "type": "Actor",
-      "name": "Sean Astin",
-      "tvdb_id": 1328
+      "imdb_id": "nm0680983",
+      "tvdb_id": 27578,
+      "name": "Elliot Page"
     }
   ]
 }

--- a/puzzles/2023-05-12.json
+++ b/puzzles/2023-05-12.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 7060,
-  "target_tvdb_id": 976,
-  "source_imdb_id": "nm0293509",
-  "target_imdb_id": "nm0005458",
+  "source_tvdb_id": 93210,
+  "target_tvdb_id": 131,
+  "source_imdb_id": "nm1727304",
+  "target_imdb_id": "nm0350453",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0293509",
       "type": "Actor",
-      "name": "Martin Freeman",
-      "tvdb_id": 7060
+      "imdb_id": "nm1727304",
+      "tvdb_id": 93210,
+      "name": "Domhnall Gleeson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1170358",
-      "votes": 677164,
+      "imdb_id": "tt2194499",
+      "votes": 362937,
       "rating": 7.8,
-      "name": "The Hobbit: The Desolation of Smaug",
-      "tvdb_id": 57158
+      "name": "About Time",
+      "tvdb_id": 122906
     },
     {
-      "imdb_id": "nm1812656",
       "type": "Actor",
-      "name": "Luke Evans",
-      "tvdb_id": 114019
+      "imdb_id": "nm1046097",
+      "tvdb_id": 53714,
+      "name": "Rachel McAdams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2820852",
-      "votes": 397640,
-      "rating": 7.1,
-      "name": "Furious 7",
-      "tvdb_id": 168259
+      "imdb_id": "tt1798684",
+      "votes": 246107,
+      "rating": 7.3,
+      "name": "Southpaw",
+      "tvdb_id": 307081
     },
     {
-      "imdb_id": "nm0005458",
       "type": "Actor",
-      "name": "Jason Statham",
-      "tvdb_id": 976
+      "imdb_id": "nm0350453",
+      "tvdb_id": 131,
+      "name": "Jake Gyllenhaal"
     }
   ]
 }

--- a/puzzles/2023-05-13.json
+++ b/puzzles/2023-05-13.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 134,
-  "target_tvdb_id": 738,
-  "source_imdb_id": "nm0004937",
-  "target_imdb_id": "nm0000125",
+  "source_tvdb_id": 1037,
+  "target_tvdb_id": 19274,
+  "source_imdb_id": "nm0000172",
+  "target_imdb_id": "nm0736622",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0004937",
       "type": "Actor",
-      "name": "Jamie Foxx",
-      "tvdb_id": 134
+      "imdb_id": "nm0000172",
+      "tvdb_id": 1037,
+      "name": "Harvey Keitel"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0350258",
-      "votes": 151577,
-      "rating": 7.7,
-      "name": "Ray",
-      "tvdb_id": 1677
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
     },
     {
-      "imdb_id": "nm0940158",
       "type": "Actor",
-      "name": "Bokeem Woodbine",
-      "tvdb_id": 71913
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0117500",
-      "votes": 345978,
-      "rating": 7.4,
-      "name": "The Rock",
-      "tvdb_id": 9802
+      "imdb_id": "tt2080374",
+      "votes": 172931,
+      "rating": 7.2,
+      "name": "Steve Jobs",
+      "tvdb_id": 321697
     },
     {
-      "imdb_id": "nm0000125",
       "type": "Actor",
-      "name": "Sean Connery",
-      "tvdb_id": 738
+      "imdb_id": "nm0736622",
+      "tvdb_id": 19274,
+      "name": "Seth Rogen"
     }
   ]
 }

--- a/puzzles/2023-05-14.json
+++ b/puzzles/2023-05-14.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 70851,
-  "target_tvdb_id": 934,
-  "source_imdb_id": "nm0085312",
-  "target_imdb_id": "nm0000128",
+  "source_tvdb_id": 112,
+  "target_tvdb_id": 204,
+  "source_imdb_id": "nm0000949",
+  "target_imdb_id": "nm0000701",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0085312",
       "type": "Actor",
-      "name": "Jack Black",
-      "tvdb_id": 70851
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0268380",
-      "votes": 494996,
-      "rating": 7.5,
-      "name": "Ice Age",
-      "tvdb_id": 425
+      "imdb_id": "tt11286314",
+      "votes": 555062,
+      "rating": 7.2,
+      "name": "Don't Look Up",
+      "tvdb_id": 646380
     },
     {
-      "imdb_id": "nm0876138",
       "type": "Actor",
-      "name": "Alan Tudyk",
-      "tvdb_id": 21088
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0381849",
-      "votes": 319366,
-      "rating": 7.7,
-      "name": "3:10 to Yuma",
-      "tvdb_id": 5176
+      "imdb_id": "tt0120338",
+      "votes": 1215558,
+      "rating": 7.9,
+      "name": "Titanic",
+      "tvdb_id": 597
     },
     {
-      "imdb_id": "nm0000128",
       "type": "Actor",
-      "name": "Russell Crowe",
-      "tvdb_id": 934
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
     }
   ]
 }

--- a/puzzles/2023-05-15.json
+++ b/puzzles/2023-05-15.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 27319,
-  "target_tvdb_id": 18269,
-  "source_imdb_id": "nm0910607",
-  "target_imdb_id": "nm0000409",
+  "source_tvdb_id": 65731,
+  "target_tvdb_id": 13240,
+  "source_imdb_id": "nm0941777",
+  "target_imdb_id": "nm0000242",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0910607",
       "type": "Actor",
-      "name": "Christoph Waltz",
-      "tvdb_id": 27319
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1389072",
-      "votes": 115232,
-      "rating": 5.8,
-      "name": "Downsizing",
-      "tvdb_id": 301337
+      "imdb_id": "tt0499549",
+      "votes": 1338763,
+      "rating": 7.9,
+      "name": "Avatar",
+      "tvdb_id": 19995
     },
     {
-      "imdb_id": "nm2186865",
       "type": "Actor",
-      "name": "Hong Chau",
-      "tvdb_id": 1360317
+      "imdb_id": "nm0000610",
+      "tvdb_id": 1771,
+      "name": "Giovanni Ribisi"
     },
     {
       "type": "Film",
-      "imdb_id": "tt13833688",
-      "votes": 135844,
-      "rating": 7.7,
-      "name": "The Whale",
-      "tvdb_id": 785084
+      "imdb_id": "tt1637725",
+      "votes": 627643,
+      "rating": 6.9,
+      "name": "Ted",
+      "tvdb_id": 72105
     },
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
     }
   ]
 }

--- a/puzzles/2023-05-16.json
+++ b/puzzles/2023-05-16.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 38673,
-  "target_tvdb_id": 37917,
-  "source_imdb_id": "nm1475594",
-  "target_imdb_id": "nm0829576",
+  "source_tvdb_id": 73968,
+  "target_tvdb_id": 2,
+  "source_imdb_id": "nm0147147",
+  "target_imdb_id": "nm0000434",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm1475594",
       "type": "Actor",
-      "name": "Channing Tatum",
-      "tvdb_id": 38673
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2334879",
-      "votes": 227903,
-      "rating": 6.3,
-      "name": "White House Down",
-      "tvdb_id": 117251
+      "imdb_id": "tt2975590",
+      "votes": 710461,
+      "rating": 6.4,
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
     },
     {
-      "imdb_id": "nm0498956",
       "type": "Actor",
-      "name": "Rachelle Lefevre",
-      "tvdb_id": 58168
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1099212",
-      "votes": 470393,
-      "rating": 5.3,
-      "name": "Twilight",
-      "tvdb_id": 8966
+      "imdb_id": "tt0261392",
+      "votes": 157679,
+      "rating": 6.8,
+      "name": "Jay and Silent Bob Strike Back",
+      "tvdb_id": 2294
     },
     {
-      "imdb_id": "nm0829576",
       "type": "Actor",
-      "name": "Kristen Stewart",
-      "tvdb_id": 37917
+      "imdb_id": "nm0000434",
+      "tvdb_id": 2,
+      "name": "Mark Hamill"
     }
   ]
 }

--- a/puzzles/2023-05-17.json
+++ b/puzzles/2023-05-17.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 190,
-  "target_tvdb_id": 1327,
-  "source_imdb_id": "nm0000142",
-  "target_imdb_id": "nm0005212",
+  "source_tvdb_id": 19274,
+  "target_tvdb_id": 2461,
+  "source_imdb_id": "nm0736622",
+  "target_imdb_id": "nm0000154",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000142",
       "type": "Actor",
-      "name": "Clint Eastwood",
-      "tvdb_id": 190
+      "imdb_id": "nm0736622",
+      "tvdb_id": 19274,
+      "name": "Seth Rogen"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1205489",
-      "votes": 787557,
-      "rating": 8.1,
-      "name": "Gran Torino",
-      "tvdb_id": 13223
+      "imdb_id": "tt0990407",
+      "votes": 162331,
+      "rating": 5.8,
+      "name": "The Green Hornet",
+      "tvdb_id": 40805
     },
     {
-      "imdb_id": "nm7419291",
       "type": "Actor",
-      "name": "Arnold Montey",
-      "tvdb_id": null
+      "imdb_id": "nm0929489",
+      "tvdb_id": 207,
+      "name": "Tom Wilkinson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0120737",
-      "votes": 1909585,
-      "rating": 8.8,
-      "name": "The Lord of the Rings: The Fellowship of the Ring",
-      "tvdb_id": 120
+      "imdb_id": "tt0187393",
+      "votes": 281910,
+      "rating": 7.2,
+      "name": "The Patriot",
+      "tvdb_id": 2024
     },
     {
-      "imdb_id": "nm0005212",
       "type": "Actor",
-      "name": "Ian McKellen",
-      "tvdb_id": 1327
+      "imdb_id": "nm0000154",
+      "tvdb_id": 2461,
+      "name": "Mel Gibson"
     }
   ]
 }

--- a/puzzles/2023-05-18.json
+++ b/puzzles/2023-05-18.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 6384,
-  "target_tvdb_id": 1283,
-  "source_imdb_id": "nm0000206",
-  "target_imdb_id": "nm0000307",
+  "source_tvdb_id": 3129,
+  "target_tvdb_id": 3061,
+  "source_imdb_id": "nm0000619",
+  "target_imdb_id": "nm0000191",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000206",
       "type": "Actor",
-      "name": "Keanu Reeves",
-      "tvdb_id": 6384
+      "imdb_id": "nm0000619",
+      "tvdb_id": 3129,
+      "name": "Tim Roth"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0219699",
-      "votes": 71676,
-      "rating": 6.7,
-      "name": "The Gift",
-      "tvdb_id": 2046
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
     },
     {
-      "imdb_id": "nm0000949",
       "type": "Actor",
-      "name": "Cate Blanchett",
-      "tvdb_id": 112
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1661199",
-      "votes": 181826,
-      "rating": 6.9,
-      "name": "Cinderella",
-      "tvdb_id": 150689
+      "imdb_id": "tt0121766",
+      "votes": 808568,
+      "rating": 7.6,
+      "name": "Star Wars: Episode III - Revenge of the Sith",
+      "tvdb_id": 1895
     },
     {
-      "imdb_id": "nm0000307",
       "type": "Actor",
-      "name": "Helena Bonham Carter",
-      "tvdb_id": 1283
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
     }
   ]
 }

--- a/puzzles/2023-05-19.json
+++ b/puzzles/2023-05-19.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1327,
-  "target_tvdb_id": 854,
-  "source_imdb_id": "nm0005212",
-  "target_imdb_id": "nm0000071",
+  "source_tvdb_id": 7060,
+  "target_tvdb_id": 2231,
+  "source_imdb_id": "nm0293509",
+  "target_imdb_id": "nm0000168",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0005212",
       "type": "Actor",
-      "name": "Ian McKellen",
-      "tvdb_id": 1327
+      "imdb_id": "nm0293509",
+      "tvdb_id": 7060,
+      "name": "Martin Freeman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0376994",
-      "votes": 525602,
-      "rating": 6.6,
-      "name": "X-Men: The Last Stand",
-      "tvdb_id": 36668
+      "imdb_id": "tt3498820",
+      "votes": 807650,
+      "rating": 7.8,
+      "name": "Captain America: Civil War",
+      "tvdb_id": 271110
     },
     {
-      "imdb_id": "nm0004886",
       "type": "Actor",
-      "name": "Bill Duke",
-      "tvdb_id": 1103
+      "imdb_id": "nm0262635",
+      "tvdb_id": 16828,
+      "name": "Chris Evans"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt1843866",
+      "votes": 862951,
+      "rating": 7.8,
+      "name": "Captain America: The Winter Soldier",
+      "tvdb_id": 100402
     },
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
     }
   ]
 }

--- a/puzzles/2023-05-20.json
+++ b/puzzles/2023-05-20.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 10205,
-  "target_tvdb_id": 530,
-  "source_imdb_id": "nm0000244",
-  "target_imdb_id": "nm0005251",
+  "source_tvdb_id": 854,
+  "target_tvdb_id": 2228,
+  "source_imdb_id": "nm0000071",
+  "target_imdb_id": "nm0000576",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000244",
       "type": "Actor",
-      "name": "Sigourney Weaver",
-      "tvdb_id": 10205
+      "imdb_id": "nm0000071",
+      "tvdb_id": 854,
+      "name": "James Stewart"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0311289",
-      "votes": 93563,
-      "rating": 7.0,
-      "name": "Holes",
-      "tvdb_id": 8326
+      "imdb_id": "tt0052561",
+      "votes": 68204,
+      "rating": 8.0,
+      "name": "Anatomy of a Murder",
+      "tvdb_id": 93
     },
     {
-      "imdb_id": "nm0479471",
       "type": "Actor",
-      "name": "Shia LaBeouf",
-      "tvdb_id": 10959
+      "imdb_id": "nm0004730",
+      "tvdb_id": 863,
+      "name": "Orson Bean"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0486822",
-      "votes": 240336,
-      "rating": 6.8,
-      "name": "Disturbia",
-      "tvdb_id": 8271
+      "imdb_id": "tt0120601",
+      "votes": 343045,
+      "rating": 7.7,
+      "name": "Being John Malkovich",
+      "tvdb_id": 492
     },
     {
-      "imdb_id": "nm0005251",
       "type": "Actor",
-      "name": "Carrie-Anne Moss",
-      "tvdb_id": 530
+      "imdb_id": "nm0000576",
+      "tvdb_id": 2228,
+      "name": "Sean Penn"
     }
   ]
 }

--- a/puzzles/2023-05-21.json
+++ b/puzzles/2023-05-21.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 4756,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm0000111",
+  "source_tvdb_id": 228,
+  "target_tvdb_id": 8691,
+  "source_imdb_id": "nm0000438",
+  "target_imdb_id": "nm0757855",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0000438",
+      "tvdb_id": 228,
+      "name": "Ed Harris"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0119190",
-      "votes": 81411,
-      "rating": 5.5,
-      "name": "George of the Jungle",
-      "tvdb_id": 10603
+      "imdb_id": "tt1568338",
+      "votes": 155207,
+      "rating": 6.6,
+      "name": "Man on a Ledge",
+      "tvdb_id": 49527
     },
     {
-      "imdb_id": "nm0005182",
       "type": "Actor",
-      "name": "Leslie Mann",
-      "tvdb_id": 41087
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0115798",
-      "votes": 170281,
-      "rating": 6.1,
-      "name": "The Cable Guy",
-      "tvdb_id": 9894
+      "imdb_id": "tt0499549",
+      "votes": 1338763,
+      "rating": 7.9,
+      "name": "Avatar",
+      "tvdb_id": 19995
     },
     {
-      "imdb_id": "nm0000111",
       "type": "Actor",
-      "name": "Matthew Broderick",
-      "tvdb_id": 4756
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
     }
   ]
 }

--- a/puzzles/2023-05-22.json
+++ b/puzzles/2023-05-22.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1100,
-  "target_tvdb_id": 6161,
-  "source_imdb_id": "nm0000216",
-  "target_imdb_id": "nm0000124",
+  "source_tvdb_id": 9273,
+  "target_tvdb_id": 1813,
+  "source_imdb_id": "nm0010736",
+  "target_imdb_id": "nm0004266",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000216",
       "type": "Actor",
-      "name": "Arnold Schwarzenegger",
-      "tvdb_id": 1100
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0146675",
-      "votes": 113052,
-      "rating": 5.8,
-      "name": "End of Days",
-      "tvdb_id": 9946
+      "imdb_id": "tt1800241",
+      "votes": 487634,
+      "rating": 7.2,
+      "name": "American Hustle",
+      "tvdb_id": 168672
     },
     {
-      "imdb_id": "nm0546797",
       "type": "Actor",
-      "name": "Mark Margolis",
-      "tvdb_id": 1173
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0180093",
-      "votes": 858944,
-      "rating": 8.3,
-      "name": "Requiem for a Dream",
-      "tvdb_id": 641
+      "imdb_id": "tt1345836",
+      "votes": 1735537,
+      "rating": 8.4,
+      "name": "The Dark Knight Rises",
+      "tvdb_id": 49026
     },
     {
-      "imdb_id": "nm0000124",
       "type": "Actor",
-      "name": "Jennifer Connelly",
-      "tvdb_id": 6161
+      "imdb_id": "nm0004266",
+      "tvdb_id": 1813,
+      "name": "Anne Hathaway"
     }
   ]
 }

--- a/puzzles/2023-05-23.json
+++ b/puzzles/2023-05-23.json
@@ -1,57 +1,44 @@
 {
-  "source_tvdb_id": 585902,
-  "target_tvdb_id": 53714,
-  "source_imdb_id": "nm0032370",
-  "target_imdb_id": "nm1046097",
-  "min_moves_to_solve": 5,
+  "source_tvdb_id": 819,
+  "target_tvdb_id": 1367,
+  "source_imdb_id": "nm0001570",
+  "target_imdb_id": "nm0397102",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0032370",
       "type": "Actor",
-      "name": "Noel Appleby",
-      "tvdb_id": 585902
+      "imdb_id": "nm0001570",
+      "tvdb_id": 819,
+      "name": "Edward Norton"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0167260",
-      "votes": 1880701,
-      "rating": 9.0,
-      "name": "The Lord of the Rings: The Return of the King",
-      "tvdb_id": 122
+      "imdb_id": "tt0800080",
+      "votes": 503379,
+      "rating": 6.6,
+      "name": "The Incredible Hulk",
+      "tvdb_id": 1724
     },
     {
-      "imdb_id": "nm0000949",
       "type": "Actor",
-      "name": "Cate Blanchett",
-      "tvdb_id": 112
+      "imdb_id": "nm0000239",
+      "tvdb_id": 882,
+      "name": "Liv Tyler"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3501632",
-      "votes": 771855,
-      "rating": 7.9,
-      "name": "Thor: Ragnarok",
-      "tvdb_id": 284053
+      "imdb_id": "tt0120737",
+      "votes": 1909585,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Fellowship of the Ring",
+      "tvdb_id": 120
     },
     {
-      "imdb_id": "nm1212722",
       "type": "Actor",
-      "name": "Benedict Cumberbatch",
-      "tvdb_id": 71580
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt1211837",
-      "votes": 761886,
-      "rating": 7.5,
-      "name": "Doctor Strange",
-      "tvdb_id": 284052
-    },
-    {
-      "imdb_id": "nm1046097",
-      "type": "Actor",
-      "name": "Rachel McAdams",
-      "tvdb_id": 53714
+      "imdb_id": "nm0397102",
+      "tvdb_id": 1367,
+      "name": "Alan Howard"
     }
   ]
 }

--- a/puzzles/2023-05-24.json
+++ b/puzzles/2023-05-24.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 530,
-  "target_tvdb_id": 4495,
-  "source_imdb_id": "nm0005251",
-  "target_imdb_id": "nm0136797",
+  "source_tvdb_id": 205,
+  "target_tvdb_id": 74568,
+  "source_imdb_id": "nm0000379",
+  "target_imdb_id": "nm1165110",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0005251",
       "type": "Actor",
-      "name": "Carrie-Anne Moss",
-      "tvdb_id": 530
+      "imdb_id": "nm0000379",
+      "tvdb_id": 205,
+      "name": "Kirsten Dunst"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0199753",
-      "votes": 58959,
-      "rating": 5.7,
-      "name": "Red Planet",
-      "tvdb_id": 8870
+      "imdb_id": "tt0338013",
+      "votes": 1027917,
+      "rating": 8.3,
+      "name": "Eternal Sunshine of the Spotless Mind",
+      "tvdb_id": 38
     },
     {
-      "imdb_id": "nm0000973",
       "type": "Actor",
-      "name": "Benjamin Bratt",
-      "tvdb_id": 4589
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1690953",
-      "votes": 409188,
-      "rating": 7.3,
-      "name": "Despicable Me 2",
-      "tvdb_id": 93456
+      "imdb_id": "tt0848228",
+      "votes": 1411541,
+      "rating": 8.0,
+      "name": "The Avengers",
+      "tvdb_id": 24428
     },
     {
-      "imdb_id": "nm0136797",
       "type": "Actor",
-      "name": "Steve Carell",
-      "tvdb_id": 4495
+      "imdb_id": "nm1165110",
+      "tvdb_id": 74568,
+      "name": "Chris Hemsworth"
     }
   ]
 }

--- a/puzzles/2023-05-25.json
+++ b/puzzles/2023-05-25.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 30614,
-  "target_tvdb_id": 2387,
-  "source_imdb_id": "nm0331516",
-  "target_imdb_id": "nm0001772",
+  "source_tvdb_id": 1327,
+  "target_tvdb_id": 1204,
+  "source_imdb_id": "nm0005212",
+  "target_imdb_id": "nm0000210",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0331516",
       "type": "Actor",
-      "name": "Ryan Gosling",
-      "tvdb_id": 30614
+      "imdb_id": "nm0005212",
+      "tvdb_id": 1327,
+      "name": "Ian McKellen"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3783958",
-      "votes": 612272,
-      "rating": 8.0,
-      "name": "La La Land",
-      "tvdb_id": 313369
+      "imdb_id": "tt0382625",
+      "votes": 442663,
+      "rating": 6.6,
+      "name": "The Da Vinci Code",
+      "tvdb_id": 591
     },
     {
-      "imdb_id": "nm0001117",
       "type": "Actor",
-      "name": "Bruce Davison",
-      "tvdb_id": 52374
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0290334",
-      "votes": 559518,
-      "rating": 7.4,
-      "name": "X2: X-Men United",
-      "tvdb_id": 36658
+      "imdb_id": "tt0472062",
+      "votes": 121255,
+      "rating": 7.0,
+      "name": "Charlie Wilson's War",
+      "tvdb_id": 6538
     },
     {
-      "imdb_id": "nm0001772",
       "type": "Actor",
-      "name": "Patrick Stewart",
-      "tvdb_id": 2387
+      "imdb_id": "nm0000210",
+      "tvdb_id": 1204,
+      "name": "Julia Roberts"
     }
   ]
 }

--- a/puzzles/2023-05-26.json
+++ b/puzzles/2023-05-26.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 514,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm0000197",
+  "source_tvdb_id": 1283,
+  "target_tvdb_id": 17288,
+  "source_imdb_id": "nm0000307",
+  "target_imdb_id": "nm1055413",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0000307",
+      "tvdb_id": 1283,
+      "name": "Helena Bonham Carter"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0120616",
-      "votes": 442485,
-      "rating": 7.1,
-      "name": "The Mummy",
-      "tvdb_id": 564
+      "imdb_id": "tt0137523",
+      "votes": 2176824,
+      "rating": 8.8,
+      "name": "Fight Club",
+      "tvdb_id": 550
     },
     {
-      "imdb_id": "nm0153704",
       "type": "Actor",
-      "name": "Carl Chase",
-      "tvdb_id": 127166
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0096895",
-      "votes": 385918,
-      "rating": 7.5,
-      "name": "Batman",
-      "tvdb_id": 268
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
     },
     {
-      "imdb_id": "nm0000197",
       "type": "Actor",
-      "name": "Jack Nicholson",
-      "tvdb_id": 514
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
     }
   ]
 }

--- a/puzzles/2023-05-27.json
+++ b/puzzles/2023-05-27.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 1269,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm0000126",
+  "source_tvdb_id": 6162,
+  "target_tvdb_id": 3490,
+  "source_imdb_id": "nm0079273",
+  "target_imdb_id": "nm0004778",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0079273",
+      "tvdb_id": 6162,
+      "name": "Paul Bettany"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0494238",
-      "votes": 80105,
-      "rating": 6.1,
-      "name": "Inkheart",
-      "tvdb_id": 2309
+      "imdb_id": "tt2395427",
+      "votes": 881783,
+      "rating": 7.3,
+      "name": "Avengers: Age of Ultron",
+      "tvdb_id": 99861
     },
     {
-      "imdb_id": "nm0833380",
       "type": "Actor",
-      "name": "Richard Strange",
-      "tvdb_id": 79502
+      "imdb_id": "nm0470981",
+      "tvdb_id": 3491,
+      "name": "Thomas Kretschmann"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0102798",
-      "votes": 199967,
-      "rating": 6.9,
-      "name": "Robin Hood: Prince of Thieves",
-      "tvdb_id": 8367
+      "imdb_id": "tt0360717",
+      "votes": 432227,
+      "rating": 7.2,
+      "name": "King Kong",
+      "tvdb_id": 254
     },
     {
-      "imdb_id": "nm0000126",
       "type": "Actor",
-      "name": "Kevin Costner",
-      "tvdb_id": 1269
+      "imdb_id": "nm0004778",
+      "tvdb_id": 3490,
+      "name": "Adrien Brody"
     }
   ]
 }

--- a/puzzles/2023-05-28.json
+++ b/puzzles/2023-05-28.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1328,
-  "target_tvdb_id": 4483,
-  "source_imdb_id": "nm0000276",
-  "target_imdb_id": "nm0000163",
+  "source_tvdb_id": 2227,
+  "target_tvdb_id": 2219,
+  "source_imdb_id": "nm0000173",
+  "target_imdb_id": "nm0001497",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000276",
       "type": "Actor",
-      "name": "Sean Astin",
-      "tvdb_id": 1328
+      "imdb_id": "nm0000173",
+      "tvdb_id": 2227,
+      "name": "Nicole Kidman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0108002",
-      "votes": 65853,
-      "rating": 7.5,
-      "name": "Rudy",
-      "tvdb_id": 14534
+      "imdb_id": "tt1477834",
+      "votes": 488838,
+      "rating": 6.8,
+      "name": "Aquaman",
+      "tvdb_id": 297802
     },
     {
-      "imdb_id": "nm0269463",
       "type": "Actor",
-      "name": "Jon Favreau",
-      "tvdb_id": 15277
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2883512",
-      "votes": 221829,
-      "rating": 7.3,
-      "name": "Chef",
-      "tvdb_id": 212778
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
     },
     {
-      "imdb_id": "nm0000163",
       "type": "Actor",
-      "name": "Dustin Hoffman",
-      "tvdb_id": 4483
+      "imdb_id": "nm0001497",
+      "tvdb_id": 2219,
+      "name": "Tobey Maguire"
     }
   ]
 }

--- a/puzzles/2023-05-29.json
+++ b/puzzles/2023-05-29.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 3392,
-  "target_tvdb_id": 93210,
-  "source_imdb_id": "nm0000140",
-  "target_imdb_id": "nm1727304",
+  "source_tvdb_id": 6856,
+  "target_tvdb_id": 819,
+  "source_imdb_id": "nm0000621",
+  "target_imdb_id": "nm0001570",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000140",
       "type": "Actor",
-      "name": "Michael Douglas",
-      "tvdb_id": 3392
+      "imdb_id": "nm0000621",
+      "tvdb_id": 6856,
+      "name": "Kurt Russell"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0181865",
-      "votes": 212012,
-      "rating": 7.6,
-      "name": "Traffic",
-      "tvdb_id": 1900
+      "imdb_id": "tt3460252",
+      "votes": 620842,
+      "rating": 7.8,
+      "name": "The Hateful Eight",
+      "tvdb_id": 273248
     },
     {
-      "imdb_id": "nm0001125",
       "type": "Actor",
-      "name": "Benicio Del Toro",
-      "tvdb_id": 1121
+      "imdb_id": "nm0000619",
+      "tvdb_id": 3129,
+      "name": "Tim Roth"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2527336",
-      "votes": 645544,
-      "rating": 6.9,
-      "name": "Star Wars: Episode VIII - The Last Jedi",
-      "tvdb_id": 181808
+      "imdb_id": "tt0800080",
+      "votes": 503379,
+      "rating": 6.6,
+      "name": "The Incredible Hulk",
+      "tvdb_id": 1724
     },
     {
-      "imdb_id": "nm1727304",
       "type": "Actor",
-      "name": "Domhnall Gleeson",
-      "tvdb_id": 93210
+      "imdb_id": "nm0001570",
+      "tvdb_id": 819,
+      "name": "Edward Norton"
     }
   ]
 }

--- a/puzzles/2023-05-30.json
+++ b/puzzles/2023-05-30.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 854,
-  "target_tvdb_id": 3895,
-  "source_imdb_id": "nm0000071",
-  "target_imdb_id": "nm0000323",
+  "source_tvdb_id": 16851,
+  "target_tvdb_id": 17276,
+  "source_imdb_id": "nm0000982",
+  "target_imdb_id": "nm0124930",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0000982",
+      "tvdb_id": 16851,
+      "name": "Josh Brolin"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt0475290",
+      "votes": 138639,
+      "rating": 6.3,
+      "name": "Hail, Caesar!",
+      "tvdb_id": 270487
     },
     {
-      "imdb_id": "nm0000168",
       "type": "Actor",
-      "name": "Samuel L. Jackson",
-      "tvdb_id": 2231
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2802144",
-      "votes": 683363,
-      "rating": 7.7,
-      "name": "Kingsman: The Secret Service",
-      "tvdb_id": 207703
+      "imdb_id": "tt0892769",
+      "votes": 758216,
+      "rating": 8.1,
+      "name": "How to Train Your Dragon",
+      "tvdb_id": 10191
     },
     {
-      "imdb_id": "nm0000323",
       "type": "Actor",
-      "name": "Michael Caine",
-      "tvdb_id": 3895
+      "imdb_id": "nm0124930",
+      "tvdb_id": 17276,
+      "name": "Gerard Butler"
     }
   ]
 }

--- a/puzzles/2023-05-31.json
+++ b/puzzles/2023-05-31.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 6941,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm0000139",
+  "source_tvdb_id": 190,
+  "target_tvdb_id": 206,
+  "source_imdb_id": "nm0000142",
+  "target_imdb_id": "nm0000120",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0000142",
+      "tvdb_id": 190,
+      "name": "Clint Eastwood"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0375679",
-      "votes": 441805,
-      "rating": 7.7,
-      "name": "Crash",
-      "tvdb_id": 1640
+      "imdb_id": "tt0405159",
+      "votes": 698263,
+      "rating": 8.1,
+      "name": "Million Dollar Baby",
+      "tvdb_id": 70
     },
     {
-      "imdb_id": "nm0000369",
       "type": "Actor",
-      "name": "Matt Dillon",
-      "tvdb_id": 2876
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0129387",
-      "votes": 318188,
-      "rating": 7.1,
-      "name": "There's Something About Mary",
-      "tvdb_id": 544
+      "imdb_id": "tt0315327",
+      "votes": 414438,
+      "rating": 6.8,
+      "name": "Bruce Almighty",
+      "tvdb_id": 310
     },
     {
-      "imdb_id": "nm0000139",
       "type": "Actor",
-      "name": "Cameron Diaz",
-      "tvdb_id": 6941
+      "imdb_id": "nm0000120",
+      "tvdb_id": 206,
+      "name": "Jim Carrey"
     }
   ]
 }

--- a/puzzles/2023-06-01.json
+++ b/puzzles/2023-06-01.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4517,
-  "target_tvdb_id": 2975,
-  "source_imdb_id": "nm0000582",
-  "target_imdb_id": "nm0000401",
+  "source_tvdb_id": 192,
+  "target_tvdb_id": 3967,
+  "source_imdb_id": "nm0000151",
+  "target_imdb_id": "nm0000295",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000582",
       "type": "Actor",
-      "name": "Joe Pesci",
-      "tvdb_id": 4517
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1302006",
-      "votes": 401561,
-      "rating": 7.8,
-      "name": "The Irishman",
-      "tvdb_id": 398978
+      "imdb_id": "tt0425210",
+      "votes": 318459,
+      "rating": 7.7,
+      "name": "Lucky Number Slevin",
+      "tvdb_id": 186
     },
     {
-      "imdb_id": "nm0000172",
       "type": "Actor",
-      "name": "Harvey Keitel",
-      "tvdb_id": 1037
+      "imdb_id": "nm0001326",
+      "tvdb_id": 2299,
+      "name": "Josh Hartnett"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0078788",
-      "votes": 680101,
-      "rating": 8.5,
-      "name": "Apocalypse Now",
-      "tvdb_id": 28
+      "imdb_id": "tt0213149",
+      "votes": 339910,
+      "rating": 6.2,
+      "name": "Pearl Harbor",
+      "tvdb_id": 676
     },
     {
-      "imdb_id": "nm0000401",
       "type": "Actor",
-      "name": "Laurence Fishburne",
-      "tvdb_id": 2975
+      "imdb_id": "nm0000295",
+      "tvdb_id": 3967,
+      "name": "Kate Beckinsale"
     }
   ]
 }

--- a/puzzles/2023-06-02.json
+++ b/puzzles/2023-06-02.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5294,
-  "target_tvdb_id": 10205,
-  "source_imdb_id": "nm0252230",
-  "target_imdb_id": "nm0000244",
+  "source_tvdb_id": 2176,
+  "target_tvdb_id": 738,
+  "source_imdb_id": "nm0000169",
+  "target_imdb_id": "nm0000125",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0252230",
       "type": "Actor",
-      "name": "Chiwetel Ejiofor",
-      "tvdb_id": 5294
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3659388",
-      "votes": 875852,
-      "rating": 8.0,
-      "name": "The Martian",
-      "tvdb_id": 286217
+      "imdb_id": "tt0106977",
+      "votes": 303662,
+      "rating": 7.8,
+      "name": "The Fugitive",
+      "tvdb_id": 5503
     },
     {
-      "imdb_id": "nm4798882",
       "type": "Actor",
-      "name": "Brad Jacobowitz",
-      "tvdb_id": null
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0090605",
-      "votes": 730298,
-      "rating": 8.4,
-      "name": "Aliens",
-      "tvdb_id": 679
+      "imdb_id": "tt0097576",
+      "votes": 768675,
+      "rating": 8.2,
+      "name": "Indiana Jones and the Last Crusade",
+      "tvdb_id": 89
     },
     {
-      "imdb_id": "nm0000244",
       "type": "Actor",
-      "name": "Sigourney Weaver",
-      "tvdb_id": 10205
+      "imdb_id": "nm0000125",
+      "tvdb_id": 738,
+      "name": "Sean Connery"
     }
   ]
 }

--- a/puzzles/2023-06-03.json
+++ b/puzzles/2023-06-03.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 114,
-  "target_tvdb_id": 37917,
-  "source_imdb_id": "nm0089217",
-  "target_imdb_id": "nm0829576",
+  "source_tvdb_id": 11701,
+  "target_tvdb_id": 776,
+  "source_imdb_id": "nm0001401",
+  "target_imdb_id": "nm0000552",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0089217",
       "type": "Actor",
-      "name": "Orlando Bloom",
-      "tvdb_id": 114
+      "imdb_id": "nm0001401",
+      "tvdb_id": 11701,
+      "name": "Angelina Jolie"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0320661",
-      "votes": 295938,
-      "rating": 7.2,
-      "name": "Kingdom of Heaven",
-      "tvdb_id": 1495
+      "imdb_id": "tt0441773",
+      "votes": 486444,
+      "rating": 7.6,
+      "name": "Kung Fu Panda",
+      "tvdb_id": 9502
     },
     {
-      "imdb_id": "nm0790688",
       "type": "Actor",
-      "name": "Michael Sheen",
-      "tvdb_id": 3968
+      "imdb_id": "nm0574534",
+      "tvdb_id": 6972,
+      "name": "Ian McShane"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1259571",
-      "votes": 290074,
-      "rating": 4.7,
-      "name": "The Twilight Saga: New Moon",
-      "tvdb_id": 18239
+      "imdb_id": "tt0413267",
+      "votes": 317481,
+      "rating": 6.1,
+      "name": "Shrek the Third",
+      "tvdb_id": 810
     },
     {
-      "imdb_id": "nm0829576",
       "type": "Actor",
-      "name": "Kristen Stewart",
-      "tvdb_id": 37917
+      "imdb_id": "nm0000552",
+      "tvdb_id": 776,
+      "name": "Eddie Murphy"
     }
   ]
 }

--- a/puzzles/2023-06-04.json
+++ b/puzzles/2023-06-04.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 44735,
-  "target_tvdb_id": 1229,
-  "source_imdb_id": "nm0251986",
-  "target_imdb_id": "nm0000313",
+  "source_tvdb_id": 11701,
+  "target_tvdb_id": 819,
+  "source_imdb_id": "nm0001401",
+  "target_imdb_id": "nm0001570",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0251986",
       "type": "Actor",
-      "name": "Jesse Eisenberg",
-      "tvdb_id": 44735
+      "imdb_id": "nm0001401",
+      "tvdb_id": 11701,
+      "name": "Angelina Jolie"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1156398",
-      "votes": 593204,
-      "rating": 7.6,
-      "name": "Zombieland",
-      "tvdb_id": 19908
+      "imdb_id": "tt0356910",
+      "votes": 509876,
+      "rating": 6.5,
+      "name": "Mr. & Mrs. Smith",
+      "tvdb_id": 787
     },
     {
-      "imdb_id": "nm4798882",
       "type": "Actor",
-      "name": "Brad Jacobowitz",
-      "tvdb_id": null
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1403865",
-      "votes": 346030,
-      "rating": 7.6,
-      "name": "True Grit",
-      "tvdb_id": 44264
+      "imdb_id": "tt0137523",
+      "votes": 2176824,
+      "rating": 8.8,
+      "name": "Fight Club",
+      "tvdb_id": 550
     },
     {
-      "imdb_id": "nm0000313",
       "type": "Actor",
-      "name": "Jeff Bridges",
-      "tvdb_id": 1229
+      "imdb_id": "nm0001570",
+      "tvdb_id": 819,
+      "name": "Edward Norton"
     }
   ]
 }

--- a/puzzles/2023-06-05.json
+++ b/puzzles/2023-06-05.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4756,
-  "target_tvdb_id": 5469,
-  "source_imdb_id": "nm0000111",
-  "target_imdb_id": "nm0000146",
+  "source_tvdb_id": 13240,
+  "target_tvdb_id": 9560,
+  "source_imdb_id": "nm0000242",
+  "target_imdb_id": "nm0000995",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000111",
       "type": "Actor",
-      "name": "Matthew Broderick",
-      "tvdb_id": 4756
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0115798",
-      "votes": 170281,
-      "rating": 6.1,
-      "name": "The Cable Guy",
-      "tvdb_id": 9894
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
     },
     {
-      "imdb_id": "nm0005562",
       "type": "Actor",
-      "name": "Owen Wilson",
-      "tvdb_id": 887
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2278388",
-      "votes": 834412,
-      "rating": 8.1,
-      "name": "The Grand Budapest Hotel",
-      "tvdb_id": 120467
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
     },
     {
-      "imdb_id": "nm0000146",
       "type": "Actor",
-      "name": "Ralph Fiennes",
-      "tvdb_id": 5469
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
     }
   ]
 }

--- a/puzzles/2023-06-06.json
+++ b/puzzles/2023-06-06.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 569,
-  "target_tvdb_id": 1327,
-  "source_imdb_id": "nm0000160",
-  "target_imdb_id": "nm0005212",
+  "source_tvdb_id": 6384,
+  "target_tvdb_id": 10980,
+  "source_imdb_id": "nm0000206",
+  "target_imdb_id": "nm0705356",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000160",
       "type": "Actor",
-      "name": "Ethan Hawke",
-      "tvdb_id": 569
+      "imdb_id": "nm0000206",
+      "tvdb_id": 6384,
+      "name": "Keanu Reeves"
     },
     {
       "type": "Film",
-      "imdb_id": "tt11138512",
-      "votes": 225973,
-      "rating": 7.0,
-      "name": "The Northman",
-      "tvdb_id": 639933
+      "imdb_id": "tt0103874",
+      "votes": 224707,
+      "rating": 7.4,
+      "name": "Dracula",
+      "tvdb_id": 6114
     },
     {
-      "imdb_id": "nm0000173",
       "type": "Actor",
-      "name": "Nicole Kidman",
-      "tvdb_id": 2227
+      "imdb_id": "nm0000198",
+      "tvdb_id": 64,
+      "name": "Gary Oldman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0385752",
-      "votes": 192228,
-      "rating": 6.1,
-      "name": "The Golden Compass",
-      "tvdb_id": 2268
+      "imdb_id": "tt0304141",
+      "votes": 653016,
+      "rating": 7.9,
+      "name": "Harry Potter and the Prisoner of Azkaban",
+      "tvdb_id": 673
     },
     {
-      "imdb_id": "nm0005212",
       "type": "Actor",
-      "name": "Ian McKellen",
-      "tvdb_id": 1327
+      "imdb_id": "nm0705356",
+      "tvdb_id": 10980,
+      "name": "Daniel Radcliffe"
     }
   ]
 }

--- a/puzzles/2023-06-07.json
+++ b/puzzles/2023-06-07.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 6730,
-  "target_tvdb_id": 57755,
-  "source_imdb_id": "nm0056187",
-  "target_imdb_id": "nm0000437",
+  "source_tvdb_id": 3896,
+  "target_tvdb_id": 18269,
+  "source_imdb_id": "nm0000553",
+  "target_imdb_id": "nm0000409",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0056187",
       "type": "Actor",
-      "name": "Sacha Baron Cohen",
-      "tvdb_id": 6730
+      "imdb_id": "nm0000553",
+      "tvdb_id": 3896,
+      "name": "Liam Neeson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0970179",
-      "votes": 328128,
-      "rating": 7.5,
-      "name": "Hugo",
-      "tvdb_id": 44826
+      "imdb_id": "tt0120915",
+      "votes": 821707,
+      "rating": 6.5,
+      "name": "Star Wars: Episode I - The Phantom Menace",
+      "tvdb_id": 1893
     },
     {
-      "imdb_id": "nm0001426",
       "type": "Actor",
-      "name": "Ben Kingsley",
-      "tvdb_id": 2282
+      "imdb_id": "nm2018573",
+      "tvdb_id": 1385097,
+      "name": "Sean Cronin"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0800241",
-      "votes": 53807,
-      "rating": 6.6,
-      "name": "Transsiberian",
-      "tvdb_id": 6687
+      "imdb_id": "tt0120616",
+      "votes": 442485,
+      "rating": 7.1,
+      "name": "The Mummy",
+      "tvdb_id": 564
     },
     {
-      "imdb_id": "nm0000437",
       "type": "Actor",
-      "name": "Woody Harrelson",
-      "tvdb_id": 57755
+      "imdb_id": "nm0000409",
+      "tvdb_id": 18269,
+      "name": "Brendan Fraser"
     }
   ]
 }

--- a/puzzles/2023-06-08.json
+++ b/puzzles/2023-06-08.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1813,
-  "target_tvdb_id": 12898,
-  "source_imdb_id": "nm0004266",
-  "target_imdb_id": "nm0000741",
+  "source_tvdb_id": 62064,
+  "target_tvdb_id": 73968,
+  "source_imdb_id": "nm1517976",
+  "target_imdb_id": "nm0147147",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0004266",
       "type": "Actor",
-      "name": "Anne Hathaway",
-      "tvdb_id": 1813
+      "imdb_id": "nm1517976",
+      "tvdb_id": 62064,
+      "name": "Chris Pine"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0247638",
-      "votes": 152883,
+      "imdb_id": "tt0451279",
+      "votes": 672170,
+      "rating": 7.4,
+      "name": "Wonder Woman",
+      "tvdb_id": 297762
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm2933757",
+      "tvdb_id": 90633,
+      "name": "Gal Gadot"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2975590",
+      "votes": 710461,
       "rating": 6.4,
-      "name": "The Princess Diaries",
-      "tvdb_id": 9880
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
     },
     {
-      "imdb_id": "nm0902184",
       "type": "Actor",
-      "name": "Erik von Detten",
-      "tvdb_id": 12901
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt0114709",
-      "votes": 1014131,
-      "rating": 8.3,
-      "name": "Toy Story",
-      "tvdb_id": 862
-    },
-    {
-      "imdb_id": "nm0000741",
-      "type": "Actor",
-      "name": "Tim Allen",
-      "tvdb_id": 12898
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
     }
   ]
 }

--- a/puzzles/2023-06-09.json
+++ b/puzzles/2023-06-09.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 193,
-  "target_tvdb_id": 3131,
-  "source_imdb_id": "nm0000432",
-  "target_imdb_id": "nm0000104",
+  "source_tvdb_id": 85,
+  "target_tvdb_id": 934,
+  "source_imdb_id": "nm0000136",
+  "target_imdb_id": "nm0000128",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000432",
       "type": "Actor",
-      "name": "Gene Hackman",
-      "tvdb_id": 193
+      "imdb_id": "nm0000136",
+      "tvdb_id": 85,
+      "name": "Johnny Depp"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0159273",
-      "votes": 108587,
-      "rating": 6.4,
-      "name": "Behind Enemy Lines",
-      "tvdb_id": 8007
+      "imdb_id": "tt0325980",
+      "votes": 1149544,
+      "rating": 8.1,
+      "name": "Pirates of the Caribbean: The Curse of the Black Pearl",
+      "tvdb_id": 22
     },
     {
-      "imdb_id": "nm0021835",
       "type": "Actor",
-      "name": "Joaquim de Almeida",
-      "tvdb_id": 22462
+      "imdb_id": "nm0047549",
+      "tvdb_id": 1715,
+      "name": "David Bailie"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0112851",
-      "votes": 190570,
-      "rating": 7.1,
-      "name": "Desperado",
-      "tvdb_id": 8068
+      "imdb_id": "tt0172495",
+      "votes": 1530321,
+      "rating": 8.5,
+      "name": "Gladiator",
+      "tvdb_id": 98
     },
     {
-      "imdb_id": "nm0000104",
       "type": "Actor",
-      "name": "Antonio Banderas",
-      "tvdb_id": 3131
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
     }
   ]
 }

--- a/puzzles/2023-06-10.json
+++ b/puzzles/2023-06-10.json
@@ -1,57 +1,44 @@
 {
-  "source_tvdb_id": 228,
-  "target_tvdb_id": 854,
-  "source_imdb_id": "nm0000438",
-  "target_imdb_id": "nm0000071",
-  "min_moves_to_solve": 5,
+  "source_tvdb_id": 5294,
+  "target_tvdb_id": 530,
+  "source_imdb_id": "nm0252230",
+  "target_imdb_id": "nm0005251",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000438",
       "type": "Actor",
-      "name": "Ed Harris",
-      "tvdb_id": 228
+      "imdb_id": "nm0252230",
+      "tvdb_id": 5294,
+      "name": "Chiwetel Ejiofor"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0104348",
-      "votes": 109840,
-      "rating": 7.7,
-      "name": "Glengarry Glen Ross",
-      "tvdb_id": 9504
+      "imdb_id": "tt1211837",
+      "votes": 761886,
+      "rating": 7.5,
+      "name": "Doctor Strange",
+      "tvdb_id": 284052
     },
     {
-      "imdb_id": "nm0000199",
       "type": "Actor",
-      "name": "Al Pacino",
-      "tvdb_id": 1158
+      "imdb_id": "nm0000973",
+      "tvdb_id": 4589,
+      "name": "Benjamin Bratt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0071562",
-      "votes": 1296165,
-      "rating": 9.0,
-      "name": "The Godfather Part II",
-      "tvdb_id": 240
+      "imdb_id": "tt0199753",
+      "votes": 58959,
+      "rating": 5.7,
+      "name": "Red Planet",
+      "tvdb_id": 8870
     },
     {
-      "imdb_id": "nm0045803",
       "type": "Actor",
-      "name": "Margaret Bacon",
-      "tvdb_id": null
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt0052357",
-      "votes": 409713,
-      "rating": 8.3,
-      "name": "Vertigo",
-      "tvdb_id": 426
-    },
-    {
-      "imdb_id": "nm0000071",
-      "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0005251",
+      "tvdb_id": 530,
+      "name": "Carrie-Anne Moss"
     }
   ]
 }

--- a/puzzles/2023-06-11.json
+++ b/puzzles/2023-06-11.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 54693,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm1297015",
+  "source_tvdb_id": 10959,
+  "target_tvdb_id": 18918,
+  "source_imdb_id": "nm0479471",
+  "target_imdb_id": "nm0425005",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0479471",
+      "tvdb_id": 10959,
+      "name": "Shia LaBeouf"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0119190",
-      "votes": 81411,
-      "rating": 5.5,
-      "name": "George of the Jungle",
-      "tvdb_id": 10603
-    },
-    {
-      "imdb_id": "nm0002006",
-      "type": "Actor",
-      "name": "Thomas Haden Church",
-      "tvdb_id": 19159
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt1282140",
-      "votes": 400477,
+      "imdb_id": "tt0418279",
+      "votes": 649520,
       "rating": 7.0,
-      "name": "Easy A",
-      "tvdb_id": 37735
+      "name": "Transformers",
+      "tvdb_id": 1858
     },
     {
-      "imdb_id": "nm1297015",
       "type": "Actor",
-      "name": "Emma Stone",
-      "tvdb_id": 54693
+      "imdb_id": "nm0879085",
+      "tvdb_id": 8169,
+      "name": "Tyrese Gibson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1905041",
+      "votes": 401504,
+      "rating": 7.0,
+      "name": "Fast & Furious 6",
+      "tvdb_id": 82992
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0425005",
+      "tvdb_id": 18918,
+      "name": "Dwayne Johnson"
     }
   ]
 }

--- a/puzzles/2023-06-12.json
+++ b/puzzles/2023-06-12.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 41091,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm1325419",
+  "source_tvdb_id": 114,
+  "target_tvdb_id": 1003,
+  "source_imdb_id": "nm0089217",
+  "target_imdb_id": "nm0000606",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0089217",
+      "tvdb_id": 114,
+      "name": "Orlando Bloom"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0375679",
-      "votes": 441805,
-      "rating": 7.7,
-      "name": "Crash",
-      "tvdb_id": 1640
+      "imdb_id": "tt1170358",
+      "votes": 677164,
+      "rating": 7.8,
+      "name": "The Hobbit: The Desolation of Smaug",
+      "tvdb_id": 57158
     },
     {
-      "imdb_id": "nm0671567",
       "type": "Actor",
-      "name": "Michael Pe\u00f1a",
-      "tvdb_id": 454
+      "imdb_id": "nm0005212",
+      "tvdb_id": 1327,
+      "name": "Ian McKellen"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3659388",
-      "votes": 875852,
-      "rating": 8.0,
-      "name": "The Martian",
-      "tvdb_id": 286217
+      "imdb_id": "tt0382625",
+      "votes": 442663,
+      "rating": 6.6,
+      "name": "The Da Vinci Code",
+      "tvdb_id": 591
     },
     {
-      "imdb_id": "nm1325419",
       "type": "Actor",
-      "name": "Kristen Wiig",
-      "tvdb_id": 41091
+      "imdb_id": "nm0000606",
+      "tvdb_id": 1003,
+      "name": "Jean Reno"
     }
   ]
 }

--- a/puzzles/2023-06-13.json
+++ b/puzzles/2023-06-13.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 529,
-  "target_tvdb_id": 854,
-  "source_imdb_id": "nm0001602",
-  "target_imdb_id": "nm0000071",
+  "source_tvdb_id": 16828,
+  "target_tvdb_id": 18277,
+  "source_imdb_id": "nm0262635",
+  "target_imdb_id": "nm0000113",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0001602",
       "type": "Actor",
-      "name": "Guy Pearce",
-      "tvdb_id": 529
+      "imdb_id": "nm0262635",
+      "tvdb_id": 16828,
+      "name": "Chris Evans"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0119488",
-      "votes": 591644,
-      "rating": 8.2,
-      "name": "L.A. Confidential",
-      "tvdb_id": 2118
+      "imdb_id": "tt1706620",
+      "votes": 370425,
+      "rating": 7.1,
+      "name": "Snowpiercer",
+      "tvdb_id": 110415
     },
     {
-      "imdb_id": "nm0740951",
       "type": "Actor",
-      "name": "Thomas Rosales Jr.",
-      "tvdb_id": 43010
+      "imdb_id": "nm0000438",
+      "tvdb_id": 228,
+      "name": "Ed Harris"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt1454468",
+      "votes": 838982,
+      "rating": 7.7,
+      "name": "Gravity",
+      "tvdb_id": 49047
     },
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0000113",
+      "tvdb_id": 18277,
+      "name": "Sandra Bullock"
     }
   ]
 }

--- a/puzzles/2023-06-14.json
+++ b/puzzles/2023-06-14.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 3036,
-  "target_tvdb_id": 449,
-  "source_imdb_id": "nm0000131",
-  "target_imdb_id": "nm0059431",
+  "source_tvdb_id": 884,
+  "target_tvdb_id": 205,
+  "source_imdb_id": "nm0000114",
+  "target_imdb_id": "nm0000379",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000131",
       "type": "Actor",
-      "name": "John Cusack",
-      "tvdb_id": 3036
+      "imdb_id": "nm0000114",
+      "tvdb_id": 884,
+      "name": "Steve Buscemi"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1231587",
-      "votes": 179559,
-      "rating": 6.4,
-      "name": "Hot Tub Time Machine",
-      "tvdb_id": 23048
+      "imdb_id": "tt3874544",
+      "votes": 132482,
+      "rating": 6.3,
+      "name": "The Boss Baby",
+      "tvdb_id": 295693
     },
     {
-      "imdb_id": "nm0732497",
       "type": "Actor",
-      "name": "Craig Robinson",
-      "tvdb_id": 64342
+      "imdb_id": "nm0001497",
+      "tvdb_id": 2219,
+      "name": "Tobey Maguire"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1245492",
-      "votes": 421307,
-      "rating": 6.6,
-      "name": "This Is the End",
-      "tvdb_id": 109414
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
     },
     {
-      "imdb_id": "nm0059431",
       "type": "Actor",
-      "name": "Jay Baruchel",
-      "tvdb_id": 449
+      "imdb_id": "nm0000379",
+      "tvdb_id": 205,
+      "name": "Kirsten Dunst"
     }
   ]
 }

--- a/puzzles/2023-06-15.json
+++ b/puzzles/2023-06-15.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5472,
-  "target_tvdb_id": 16851,
-  "source_imdb_id": "nm0000147",
-  "target_imdb_id": "nm0000982",
+  "source_tvdb_id": 3087,
+  "target_tvdb_id": 37917,
+  "source_imdb_id": "nm0000380",
+  "target_imdb_id": "nm0829576",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000147",
       "type": "Actor",
-      "name": "Colin Firth",
-      "tvdb_id": 5472
+      "imdb_id": "nm0000380",
+      "tvdb_id": 3087,
+      "name": "Robert Duvall"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0314331",
-      "votes": 502629,
-      "rating": 7.6,
-      "name": "Love Actually",
-      "tvdb_id": 508
+      "imdb_id": "tt0898367",
+      "votes": 244967,
+      "rating": 7.2,
+      "name": "The Road",
+      "tvdb_id": 20766
     },
     {
-      "imdb_id": "nm0000668",
       "type": "Actor",
-      "name": "Emma Thompson",
-      "tvdb_id": 7056
+      "imdb_id": "nm0000234",
+      "tvdb_id": 6885,
+      "name": "Charlize Theron"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1409024",
-      "votes": 371787,
-      "rating": 6.8,
-      "name": "Men in Black 3",
-      "tvdb_id": 41154
+      "imdb_id": "tt1735898",
+      "votes": 294509,
+      "rating": 6.1,
+      "name": "Snow White and the Huntsman",
+      "tvdb_id": 58595
     },
     {
-      "imdb_id": "nm0000982",
       "type": "Actor",
-      "name": "Josh Brolin",
-      "tvdb_id": 16851
+      "imdb_id": "nm0829576",
+      "tvdb_id": 37917,
+      "name": "Kristen Stewart"
     }
   ]
 }

--- a/puzzles/2023-06-16.json
+++ b/puzzles/2023-06-16.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 854,
-  "target_tvdb_id": 192,
-  "source_imdb_id": "nm0000071",
-  "target_imdb_id": "nm0000151",
+  "source_tvdb_id": 449,
+  "target_tvdb_id": 1283,
+  "source_imdb_id": "nm0059431",
+  "target_imdb_id": "nm0000307",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt1646971",
+      "votes": 346139,
+      "rating": 7.8,
+      "name": "How to Train Your Dragon 2",
+      "tvdb_id": 82702
     },
     {
-      "imdb_id": "nm0001165",
       "type": "Actor",
-      "name": "Charles S. Dutton",
-      "tvdb_id": 17764
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0114369",
-      "votes": 1690351,
-      "rating": 8.6,
-      "name": "Se7en",
-      "tvdb_id": 807
+      "imdb_id": "tt1661199",
+      "votes": 181826,
+      "rating": 6.9,
+      "name": "Cinderella",
+      "tvdb_id": 150689
     },
     {
-      "imdb_id": "nm0000151",
       "type": "Actor",
-      "name": "Morgan Freeman",
-      "tvdb_id": 192
+      "imdb_id": "nm0000307",
+      "tvdb_id": 1283,
+      "name": "Helena Bonham Carter"
     }
   ]
 }

--- a/puzzles/2023-06-17.json
+++ b/puzzles/2023-06-17.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 8167,
-  "target_tvdb_id": 3084,
-  "source_imdb_id": "nm0908094",
-  "target_imdb_id": "nm0000008",
+  "source_tvdb_id": 1810,
+  "target_tvdb_id": 23659,
+  "source_imdb_id": "nm0005132",
+  "target_imdb_id": "nm0002071",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0908094",
       "type": "Actor",
-      "name": "Paul Walker",
-      "tvdb_id": 8167
+      "imdb_id": "nm0005132",
+      "tvdb_id": 1810,
+      "name": "Heath Ledger"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0418689",
-      "votes": 125901,
-      "rating": 7.1,
-      "name": "Flags of Our Fathers",
-      "tvdb_id": 3683
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
     },
     {
-      "imdb_id": "nm0556985",
       "type": "Actor",
-      "name": "Tom Mason",
-      "tvdb_id": 80874
+      "imdb_id": "nm0350454",
+      "tvdb_id": 1579,
+      "name": "Maggie Gyllenhaal"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0078788",
-      "votes": 680101,
-      "rating": 8.5,
-      "name": "Apocalypse Now",
-      "tvdb_id": 28
+      "imdb_id": "tt0420223",
+      "votes": 232126,
+      "rating": 7.5,
+      "name": "Stranger Than Fiction",
+      "tvdb_id": 1262
     },
     {
-      "imdb_id": "nm0000008",
       "type": "Actor",
-      "name": "Marlon Brando",
-      "tvdb_id": 3084
+      "imdb_id": "nm0002071",
+      "tvdb_id": 23659,
+      "name": "Will Ferrell"
     }
   ]
 }

--- a/puzzles/2023-06-18.json
+++ b/puzzles/2023-06-18.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 3967,
-  "target_tvdb_id": 4756,
-  "source_imdb_id": "nm0000295",
-  "target_imdb_id": "nm0000111",
+  "source_tvdb_id": 4483,
+  "target_tvdb_id": 3392,
+  "source_imdb_id": "nm0000163",
+  "target_imdb_id": "nm0000140",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000295",
       "type": "Actor",
-      "name": "Kate Beckinsale",
-      "tvdb_id": 3967
+      "imdb_id": "nm0000163",
+      "tvdb_id": 4483,
+      "name": "Dustin Hoffman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0389860",
-      "votes": 340933,
-      "rating": 6.4,
-      "name": "Click",
-      "tvdb_id": 9339
+      "imdb_id": "tt0290002",
+      "votes": 277235,
+      "rating": 6.3,
+      "name": "Meet the Fockers",
+      "tvdb_id": 693
     },
     {
-      "imdb_id": "nm0000469",
       "type": "Actor",
-      "name": "James Earl Jones",
-      "tvdb_id": 15152
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0110357",
-      "votes": 1080805,
-      "rating": 8.5,
-      "name": "The Lion King",
-      "tvdb_id": 8587
+      "imdb_id": "tt1204975",
+      "votes": 134231,
+      "rating": 6.6,
+      "name": "Last Vegas",
+      "tvdb_id": 137093
     },
     {
-      "imdb_id": "nm0000111",
       "type": "Actor",
-      "name": "Matthew Broderick",
-      "tvdb_id": 4756
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
     }
   ]
 }

--- a/puzzles/2023-06-19.json
+++ b/puzzles/2023-06-19.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4756,
-  "target_tvdb_id": 22226,
-  "source_imdb_id": "nm0000111",
-  "target_imdb_id": "nm0748620",
+  "source_tvdb_id": 8691,
+  "target_tvdb_id": 93210,
+  "source_imdb_id": "nm0757855",
+  "target_imdb_id": "nm1727304",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000111",
       "type": "Actor",
-      "name": "Matthew Broderick",
-      "tvdb_id": 4756
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0115798",
-      "votes": 170281,
-      "rating": 6.1,
-      "name": "The Cable Guy",
-      "tvdb_id": 9894
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
     },
     {
-      "imdb_id": "nm0005182",
       "type": "Actor",
-      "name": "Leslie Mann",
-      "tvdb_id": 41087
+      "imdb_id": "nm0001125",
+      "tvdb_id": 1121,
+      "name": "Benicio Del Toro"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0478311",
-      "votes": 375637,
+      "imdb_id": "tt2527336",
+      "votes": 645544,
       "rating": 6.9,
-      "name": "Knocked Up",
-      "tvdb_id": 4964
+      "name": "Star Wars: Episode VIII - The Last Jedi",
+      "tvdb_id": 181808
     },
     {
-      "imdb_id": "nm0748620",
       "type": "Actor",
-      "name": "Paul Rudd",
-      "tvdb_id": 22226
+      "imdb_id": "nm1727304",
+      "tvdb_id": 93210,
+      "name": "Domhnall Gleeson"
     }
   ]
 }

--- a/puzzles/2023-06-20.json
+++ b/puzzles/2023-06-20.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 38673,
-  "target_tvdb_id": 193,
-  "source_imdb_id": "nm1475594",
-  "target_imdb_id": "nm0000432",
+  "source_tvdb_id": 1230,
+  "target_tvdb_id": 13,
+  "source_imdb_id": "nm0000422",
+  "target_imdb_id": "nm0000983",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm1475594",
       "type": "Actor",
-      "name": "Channing Tatum",
-      "tvdb_id": 38673
+      "imdb_id": "nm0000422",
+      "tvdb_id": 1230,
+      "name": "John Goodman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1490017",
-      "votes": 366969,
-      "rating": 7.7,
-      "name": "The Lego Movie",
-      "tvdb_id": 137106
+      "imdb_id": "tt0198781",
+      "votes": 928601,
+      "rating": 8.1,
+      "name": "Monsters, Inc.",
+      "tvdb_id": 585
     },
     {
-      "imdb_id": "nm0000151",
       "type": "Actor",
-      "name": "Morgan Freeman",
-      "tvdb_id": 192
+      "imdb_id": "nm0677037",
+      "tvdb_id": 10,
+      "name": "Bob Peterson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0105695",
-      "votes": 419562,
+      "imdb_id": "tt0266543",
+      "votes": 1062914,
       "rating": 8.2,
-      "name": "Unforgiven",
-      "tvdb_id": 33
+      "name": "Finding Nemo",
+      "tvdb_id": 12
     },
     {
-      "imdb_id": "nm0000432",
       "type": "Actor",
-      "name": "Gene Hackman",
-      "tvdb_id": 193
+      "imdb_id": "nm0000983",
+      "tvdb_id": 13,
+      "name": "Albert Brooks"
     }
   ]
 }

--- a/puzzles/2023-06-21.json
+++ b/puzzles/2023-06-21.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 12073,
-  "target_tvdb_id": 1229,
-  "source_imdb_id": "nm0000196",
-  "target_imdb_id": "nm0000313",
+  "source_tvdb_id": 73457,
+  "target_tvdb_id": 3895,
+  "source_imdb_id": "nm0695435",
+  "target_imdb_id": "nm0000323",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000196",
       "type": "Actor",
-      "name": "Mike Myers",
-      "tvdb_id": 12073
+      "imdb_id": "nm0695435",
+      "tvdb_id": 73457,
+      "name": "Chris Pratt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0145660",
-      "votes": 239572,
-      "rating": 6.6,
-      "name": "Austin Powers: The Spy Who Shagged Me",
-      "tvdb_id": 817
+      "imdb_id": "tt10648342",
+      "votes": 358743,
+      "rating": 6.2,
+      "name": "Thor: Love and Thunder",
+      "tvdb_id": 616037
     },
     {
-      "imdb_id": "nm0444940",
       "type": "Actor",
-      "name": "Jack Kehler",
-      "tvdb_id": 1240
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0118715",
-      "votes": 824543,
-      "rating": 8.1,
-      "name": "The Big Lebowski",
-      "tvdb_id": 115
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
     },
     {
-      "imdb_id": "nm0000313",
       "type": "Actor",
-      "name": "Jeff Bridges",
-      "tvdb_id": 1229
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
     }
   ]
 }

--- a/puzzles/2023-06-22.json
+++ b/puzzles/2023-06-22.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 530,
-  "target_tvdb_id": 4483,
-  "source_imdb_id": "nm0005251",
-  "target_imdb_id": "nm0000163",
+  "source_tvdb_id": 5064,
+  "target_tvdb_id": 17178,
+  "source_imdb_id": "nm0000658",
+  "target_imdb_id": "nm0933940",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0005251",
       "type": "Actor",
-      "name": "Carrie-Anne Moss",
-      "tvdb_id": 530
+      "imdb_id": "nm0000658",
+      "tvdb_id": 5064,
+      "name": "Meryl Streep"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0914863",
-      "votes": 89879,
-      "rating": 7.0,
-      "name": "Unthinkable",
-      "tvdb_id": 38199
+      "imdb_id": "tt0432283",
+      "votes": 243431,
+      "rating": 7.9,
+      "name": "Fantastic Mr. Fox",
+      "tvdb_id": 10315
     },
     {
-      "imdb_id": "nm0000168",
       "type": "Actor",
-      "name": "Samuel L. Jackson",
-      "tvdb_id": 2231
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0120184",
-      "votes": 108945,
-      "rating": 6.1,
-      "name": "Sphere",
-      "tvdb_id": 10153
+      "imdb_id": "tt1477834",
+      "votes": 488838,
+      "rating": 6.8,
+      "name": "Aquaman",
+      "tvdb_id": 297802
     },
     {
-      "imdb_id": "nm0000163",
       "type": "Actor",
-      "name": "Dustin Hoffman",
-      "tvdb_id": 4483
+      "imdb_id": "nm0933940",
+      "tvdb_id": 17178,
+      "name": "Patrick Wilson"
     }
   ]
 }

--- a/puzzles/2023-06-23.json
+++ b/puzzles/2023-06-23.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2228,
-  "target_tvdb_id": 1327,
-  "source_imdb_id": "nm0000576",
-  "target_imdb_id": "nm0005212",
+  "source_tvdb_id": 2157,
+  "target_tvdb_id": 10980,
+  "source_imdb_id": "nm0000245",
+  "target_imdb_id": "nm0705356",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000576",
       "type": "Actor",
-      "name": "Sean Penn",
-      "tvdb_id": 2228
+      "imdb_id": "nm0000245",
+      "tvdb_id": 2157,
+      "name": "Robin Williams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0327056",
-      "votes": 466393,
-      "rating": 7.9,
-      "name": "Mystic River",
-      "tvdb_id": 322
-    },
-    {
-      "imdb_id": "nm0001473",
-      "type": "Actor",
-      "name": "Laura Linney",
-      "tvdb_id": 350
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt3168230",
-      "votes": 65790,
+      "imdb_id": "tt0102057",
+      "votes": 262088,
       "rating": 6.8,
-      "name": "Mr. Holmes",
-      "tvdb_id": 280996
+      "name": "Hook",
+      "tvdb_id": 879
     },
     {
-      "imdb_id": "nm0005212",
       "type": "Actor",
-      "name": "Ian McKellen",
-      "tvdb_id": 1327
+      "imdb_id": "nm0001749",
+      "tvdb_id": 10978,
+      "name": "Maggie Smith"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0241527",
+      "votes": 806134,
+      "rating": 7.6,
+      "name": "Harry Potter and the Sorcerer's Stone",
+      "tvdb_id": 671
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0705356",
+      "tvdb_id": 10980,
+      "name": "Daniel Radcliffe"
     }
   ]
 }

--- a/puzzles/2023-06-24.json
+++ b/puzzles/2023-06-24.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 70851,
-  "target_tvdb_id": 71580,
-  "source_imdb_id": "nm0085312",
-  "target_imdb_id": "nm1212722",
+  "source_tvdb_id": 1331,
+  "target_tvdb_id": 7447,
+  "source_imdb_id": "nm0915989",
+  "target_imdb_id": "nm0000285",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0085312",
       "type": "Actor",
-      "name": "Jack Black",
-      "tvdb_id": 70851
+      "imdb_id": "nm0915989",
+      "tvdb_id": 1331,
+      "name": "Hugo Weaving"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2267968",
-      "votes": 168500,
-      "rating": 7.1,
-      "name": "Kung Fu Panda 3",
-      "tvdb_id": 140300
+      "imdb_id": "tt0167261",
+      "votes": 1697780,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Two Towers",
+      "tvdb_id": 121
     },
     {
-      "imdb_id": "nm0799777",
       "type": "Actor",
-      "name": "J.K. Simmons",
-      "tvdb_id": 18999
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
     },
     {
       "type": "Film",
-      "imdb_id": "tt10872600",
-      "votes": 789409,
-      "rating": 8.2,
-      "name": "Spider-Man: No Way Home",
-      "tvdb_id": 634649
+      "imdb_id": "tt0338751",
+      "votes": 370181,
+      "rating": 7.5,
+      "name": "The Aviator",
+      "tvdb_id": 2567
     },
     {
-      "imdb_id": "nm1212722",
       "type": "Actor",
-      "name": "Benedict Cumberbatch",
-      "tvdb_id": 71580
+      "imdb_id": "nm0000285",
+      "tvdb_id": 7447,
+      "name": "Alec Baldwin"
     }
   ]
 }

--- a/puzzles/2023-06-25.json
+++ b/puzzles/2023-06-25.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 70851,
-  "target_tvdb_id": 884,
-  "source_imdb_id": "nm0085312",
-  "target_imdb_id": "nm0000114",
+  "source_tvdb_id": 1269,
+  "target_tvdb_id": 5530,
+  "source_imdb_id": "nm0000126",
+  "target_imdb_id": "nm0564215",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0085312",
       "type": "Actor",
-      "name": "Jack Black",
-      "tvdb_id": 70851
+      "imdb_id": "nm0000126",
+      "tvdb_id": 1269,
+      "name": "Kevin Costner"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0441773",
-      "votes": 486444,
-      "rating": 7.6,
-      "name": "Kung Fu Panda",
-      "tvdb_id": 9502
+      "imdb_id": "tt0102798",
+      "votes": 199967,
+      "rating": 6.9,
+      "name": "Robin Hood: Prince of Thieves",
+      "tvdb_id": 8367
     },
     {
-      "imdb_id": "nm0003817",
       "type": "Actor",
-      "name": "Michael Clarke Duncan",
-      "tvdb_id": 61981
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0120591",
-      "votes": 435147,
+      "imdb_id": "tt0493464",
+      "votes": 396817,
       "rating": 6.7,
-      "name": "Armageddon",
-      "tvdb_id": 95
+      "name": "Wanted",
+      "tvdb_id": 8909
     },
     {
-      "imdb_id": "nm0000114",
       "type": "Actor",
-      "name": "Steve Buscemi",
-      "tvdb_id": 884
+      "imdb_id": "nm0564215",
+      "tvdb_id": 5530,
+      "name": "James McAvoy"
     }
   ]
 }

--- a/puzzles/2023-06-26.json
+++ b/puzzles/2023-06-26.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 54693,
-  "target_tvdb_id": 854,
-  "source_imdb_id": "nm1297015",
-  "target_imdb_id": "nm0000071",
+  "source_tvdb_id": 5294,
+  "target_tvdb_id": 1003,
+  "source_imdb_id": "nm0252230",
+  "target_imdb_id": "nm0000606",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm1297015",
       "type": "Actor",
-      "name": "Emma Stone",
-      "tvdb_id": 54693
+      "imdb_id": "nm0252230",
+      "tvdb_id": 5294,
+      "name": "Chiwetel Ejiofor"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1156398",
-      "votes": 593204,
-      "rating": 7.6,
-      "name": "Zombieland",
-      "tvdb_id": 19908
+      "imdb_id": "tt3659388",
+      "votes": 875852,
+      "rating": 8.0,
+      "name": "The Martian",
+      "tvdb_id": 286217
     },
     {
-      "imdb_id": "nm4798882",
       "type": "Actor",
-      "name": "Brad Jacobowitz",
-      "tvdb_id": null
+      "imdb_id": "nm0000293",
+      "tvdb_id": 48,
+      "name": "Sean Bean"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt0122690",
+      "votes": 187870,
+      "rating": 7.2,
+      "name": "Ronin",
+      "tvdb_id": 8195
     },
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0000606",
+      "tvdb_id": 1003,
+      "name": "Jean Reno"
     }
   ]
 }

--- a/puzzles/2023-06-27.json
+++ b/puzzles/2023-06-27.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2461,
-  "target_tvdb_id": 38673,
-  "source_imdb_id": "nm0000154",
-  "target_imdb_id": "nm1475594",
+  "source_tvdb_id": 2219,
+  "target_tvdb_id": 2440,
+  "source_imdb_id": "nm0001497",
+  "target_imdb_id": "nm0631490",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000154",
       "type": "Actor",
-      "name": "Mel Gibson",
-      "tvdb_id": 2461
+      "imdb_id": "nm0001497",
+      "tvdb_id": 2219,
+      "name": "Tobey Maguire"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1567609",
-      "votes": 109646,
-      "rating": 6.9,
-      "name": "Get the Gringo",
-      "tvdb_id": 80389
+      "imdb_id": "tt0120669",
+      "votes": 290698,
+      "rating": 7.5,
+      "name": "Fear and Loathing in Las Vegas",
+      "tvdb_id": 1878
     },
     {
-      "imdb_id": "nm0001780",
       "type": "Actor",
-      "name": "Peter Stormare",
-      "tvdb_id": 53
+      "imdb_id": "nm0000136",
+      "tvdb_id": 85,
+      "name": "Johnny Depp"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2294449",
-      "votes": 387859,
-      "rating": 7.0,
-      "name": "22 Jump Street",
-      "tvdb_id": 187017
+      "imdb_id": "tt0383574",
+      "votes": 734303,
+      "rating": 7.3,
+      "name": "Pirates of the Caribbean: Dead Man's Chest",
+      "tvdb_id": 58
     },
     {
-      "imdb_id": "nm1475594",
       "type": "Actor",
-      "name": "Channing Tatum",
-      "tvdb_id": 38673
+      "imdb_id": "nm0631490",
+      "tvdb_id": 2440,
+      "name": "Bill Nighy"
     }
   ]
 }

--- a/puzzles/2023-06-28.json
+++ b/puzzles/2023-06-28.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 16828,
-  "target_tvdb_id": 521,
-  "source_imdb_id": "nm0262635",
-  "target_imdb_id": "nm0000150",
+  "source_tvdb_id": 3036,
+  "target_tvdb_id": 6162,
+  "source_imdb_id": "nm0000131",
+  "target_imdb_id": "nm0079273",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0262635",
       "type": "Actor",
-      "name": "Chris Evans",
-      "tvdb_id": 16828
+      "imdb_id": "nm0000131",
+      "tvdb_id": 3036,
+      "name": "John Cusack"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0848228",
-      "votes": 1411541,
-      "rating": 8.0,
-      "name": "The Avengers",
-      "tvdb_id": 24428
-    },
-    {
-      "imdb_id": "nm0804592",
-      "type": "Actor",
-      "name": "Jerzy Skolimowski",
-      "tvdb_id": 43553
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt0116996",
-      "votes": 233754,
+      "imdb_id": "tt1231587",
+      "votes": 179559,
       "rating": 6.4,
-      "name": "Mars Attacks!",
-      "tvdb_id": 75
+      "name": "Hot Tub Time Machine",
+      "tvdb_id": 23048
     },
     {
-      "imdb_id": "nm0000150",
       "type": "Actor",
-      "name": "Michael J. Fox",
-      "tvdb_id": 521
+      "imdb_id": "nm1659221",
+      "tvdb_id": 60898,
+      "name": "Sebastian Stan"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3498820",
+      "votes": 807650,
+      "rating": 7.8,
+      "name": "Captain America: Civil War",
+      "tvdb_id": 271110
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0079273",
+      "tvdb_id": 6162,
+      "name": "Paul Bettany"
     }
   ]
 }

--- a/puzzles/2023-06-29.json
+++ b/puzzles/2023-06-29.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 139,
-  "target_tvdb_id": 449,
-  "source_imdb_id": "nm0000235",
-  "target_imdb_id": "nm0059431",
+  "source_tvdb_id": 21657,
+  "target_tvdb_id": 116,
+  "source_imdb_id": "nm0267812",
+  "target_imdb_id": "nm0461136",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000235",
       "type": "Actor",
-      "name": "Uma Thurman",
-      "tvdb_id": 139
+      "imdb_id": "nm0267812",
+      "tvdb_id": 21657,
+      "name": "Vera Farmiga"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0110912",
-      "votes": 2101050,
-      "rating": 8.9,
-      "name": "Pulp Fiction",
-      "tvdb_id": 680
+      "imdb_id": "tt1590193",
+      "votes": 119186,
+      "rating": 6.3,
+      "name": "The Commuter",
+      "tvdb_id": 399035
     },
     {
-      "imdb_id": "nm0000168",
       "type": "Actor",
-      "name": "Samuel L. Jackson",
-      "tvdb_id": 2231
+      "imdb_id": "nm0000553",
+      "tvdb_id": 3896,
+      "name": "Liam Neeson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1234721",
-      "votes": 232999,
-      "rating": 6.1,
-      "name": "RoboCop",
-      "tvdb_id": 97020
+      "imdb_id": "tt0120915",
+      "votes": 821707,
+      "rating": 6.5,
+      "name": "Star Wars: Episode I - The Phantom Menace",
+      "tvdb_id": 1893
     },
     {
-      "imdb_id": "nm0059431",
       "type": "Actor",
-      "name": "Jay Baruchel",
-      "tvdb_id": 449
+      "imdb_id": "nm0461136",
+      "tvdb_id": 116,
+      "name": "Keira Knightley"
     }
   ]
 }

--- a/puzzles/2023-06-30.json
+++ b/puzzles/2023-06-30.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1367,
-  "target_tvdb_id": 504,
-  "source_imdb_id": "nm0397102",
-  "target_imdb_id": "nm0000209",
+  "source_tvdb_id": 7060,
+  "target_tvdb_id": 569,
+  "source_imdb_id": "nm0293509",
+  "target_imdb_id": "nm0000160",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0397102",
       "type": "Actor",
-      "name": "Alan Howard",
-      "tvdb_id": 1367
+      "imdb_id": "nm0293509",
+      "tvdb_id": 7060,
+      "name": "Martin Freeman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0167260",
-      "votes": 1880701,
-      "rating": 9.0,
-      "name": "The Lord of the Rings: The Return of the King",
-      "tvdb_id": 122
+      "imdb_id": "tt1825683",
+      "votes": 798599,
+      "rating": 7.3,
+      "name": "Black Panther",
+      "tvdb_id": 284054
     },
     {
-      "imdb_id": "nm0001584",
       "type": "Actor",
-      "name": "Miranda Otto",
-      "tvdb_id": 502
+      "imdb_id": "nm1091701",
+      "tvdb_id": 77278,
+      "name": "Denzel Whitaker"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0407304",
-      "votes": 458497,
-      "rating": 6.5,
-      "name": "War of the Worlds",
-      "tvdb_id": 74
+      "imdb_id": "tt0139654",
+      "votes": 448538,
+      "rating": 7.7,
+      "name": "Training Day",
+      "tvdb_id": 2034
     },
     {
-      "imdb_id": "nm0000209",
       "type": "Actor",
-      "name": "Tim Robbins",
-      "tvdb_id": 504
+      "imdb_id": "nm0000160",
+      "tvdb_id": 569,
+      "name": "Ethan Hawke"
     }
   ]
 }

--- a/puzzles/2023-07-01.json
+++ b/puzzles/2023-07-01.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 530,
-  "target_tvdb_id": 3967,
-  "source_imdb_id": "nm0005251",
-  "target_imdb_id": "nm0000295",
+  "source_tvdb_id": 193,
+  "target_tvdb_id": 3131,
+  "source_imdb_id": "nm0000432",
+  "target_imdb_id": "nm0000104",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0005251",
       "type": "Actor",
-      "name": "Carrie-Anne Moss",
-      "tvdb_id": 530
+      "imdb_id": "nm0000432",
+      "tvdb_id": 193,
+      "name": "Gene Hackman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0133093",
-      "votes": 1950577,
-      "rating": 8.7,
-      "name": "The Matrix",
-      "tvdb_id": 603
+      "imdb_id": "tt0159273",
+      "votes": 108587,
+      "rating": 6.4,
+      "name": "Behind Enemy Lines",
+      "tvdb_id": 8007
     },
     {
-      "imdb_id": "nm3269395",
       "type": "Actor",
-      "name": "Rana Morrison",
-      "tvdb_id": 1209257
+      "imdb_id": "nm0021835",
+      "tvdb_id": 22462,
+      "name": "Joaquim de Almeida"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0320691",
-      "votes": 276297,
-      "rating": 7.0,
-      "name": "Underworld",
-      "tvdb_id": 277
+      "imdb_id": "tt0112851",
+      "votes": 190570,
+      "rating": 7.1,
+      "name": "Desperado",
+      "tvdb_id": 8068
     },
     {
-      "imdb_id": "nm0000295",
       "type": "Actor",
-      "name": "Kate Beckinsale",
-      "tvdb_id": 3967
+      "imdb_id": "nm0000104",
+      "tvdb_id": 3131,
+      "name": "Antonio Banderas"
     }
   ]
 }

--- a/puzzles/2023-07-02.json
+++ b/puzzles/2023-07-02.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 504,
-  "target_tvdb_id": 1367,
-  "source_imdb_id": "nm0000209",
-  "target_imdb_id": "nm0397102",
+  "source_tvdb_id": 65731,
+  "target_tvdb_id": 7399,
+  "source_imdb_id": "nm0941777",
+  "target_imdb_id": "nm0001774",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000209",
       "type": "Actor",
-      "name": "Tim Robbins",
-      "tvdb_id": 504
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0407304",
-      "votes": 458497,
-      "rating": 6.5,
-      "name": "War of the Worlds",
-      "tvdb_id": 74
+      "imdb_id": "tt0499549",
+      "votes": 1338763,
+      "rating": 7.9,
+      "name": "Avatar",
+      "tvdb_id": 19995
     },
     {
-      "imdb_id": "nm0001584",
       "type": "Actor",
-      "name": "Miranda Otto",
-      "tvdb_id": 502
+      "imdb_id": "nm0601376",
+      "tvdb_id": 59231,
+      "name": "Joel David Moore"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0167260",
-      "votes": 1880701,
-      "rating": 9.0,
-      "name": "The Lord of the Rings: The Return of the King",
-      "tvdb_id": 122
+      "imdb_id": "tt0364725",
+      "votes": 256857,
+      "rating": 6.7,
+      "name": "Dodgeball: A True Underdog Story",
+      "tvdb_id": 9472
     },
     {
-      "imdb_id": "nm0397102",
       "type": "Actor",
-      "name": "Alan Howard",
-      "tvdb_id": 1367
+      "imdb_id": "nm0001774",
+      "tvdb_id": 7399,
+      "name": "Ben Stiller"
     }
   ]
 }

--- a/puzzles/2023-07-03.json
+++ b/puzzles/2023-07-03.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 17178,
-  "target_tvdb_id": 1204,
-  "source_imdb_id": "nm0933940",
-  "target_imdb_id": "nm0000210",
+  "source_tvdb_id": 500,
+  "target_tvdb_id": 368,
+  "source_imdb_id": "nm0000129",
+  "target_imdb_id": "nm0000702",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0933940",
       "type": "Actor",
-      "name": "Patrick Wilson",
-      "tvdb_id": 17178
+      "imdb_id": "nm0000129",
+      "tvdb_id": 500,
+      "name": "Tom Cruise"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0409459",
-      "votes": 561574,
-      "rating": 7.6,
-      "name": "Watchmen",
-      "tvdb_id": 13183
+      "imdb_id": "tt0369339",
+      "votes": 414730,
+      "rating": 7.5,
+      "name": "Collateral",
+      "tvdb_id": 1538
     },
     {
-      "imdb_id": "nm0001082",
       "type": "Actor",
-      "name": "Billy Crudup",
-      "tvdb_id": 8289
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0879870",
-      "votes": 100931,
-      "rating": 5.8,
-      "name": "Eat Pray Love",
-      "tvdb_id": 38167
+      "imdb_id": "tt0425123",
+      "votes": 113684,
+      "rating": 6.7,
+      "name": "Just Like Heaven",
+      "tvdb_id": 9007
     },
     {
-      "imdb_id": "nm0000210",
       "type": "Actor",
-      "name": "Julia Roberts",
-      "tvdb_id": 1204
+      "imdb_id": "nm0000702",
+      "tvdb_id": 368,
+      "name": "Reese Witherspoon"
     }
   ]
 }

--- a/puzzles/2023-07-04.json
+++ b/puzzles/2023-07-04.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1100,
-  "target_tvdb_id": 290,
-  "source_imdb_id": "nm0000216",
-  "target_imdb_id": "nm0001626",
+  "source_tvdb_id": 6730,
+  "target_tvdb_id": 3036,
+  "source_imdb_id": "nm0056187",
+  "target_imdb_id": "nm0000131",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000216",
       "type": "Actor",
-      "name": "Arnold Schwarzenegger",
-      "tvdb_id": 1100
+      "imdb_id": "nm0056187",
+      "tvdb_id": 6730,
+      "name": "Sacha Baron Cohen"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0100802",
-      "votes": 339672,
-      "rating": 7.5,
-      "name": "Total Recall",
-      "tvdb_id": 861
+      "imdb_id": "tt1645170",
+      "votes": 317452,
+      "rating": 6.4,
+      "name": "The Dictator",
+      "tvdb_id": 76493
     },
     {
-      "imdb_id": "nm0074036",
       "type": "Actor",
-      "name": "Bob Bergen",
-      "tvdb_id": 78317
+      "imdb_id": "nm1502654",
+      "tvdb_id": 1202712,
+      "name": "Peter Conboy"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1049413",
-      "votes": 1065269,
-      "rating": 8.3,
-      "name": "Up",
-      "tvdb_id": 14160
+      "imdb_id": "tt0450385",
+      "votes": 280761,
+      "rating": 6.8,
+      "name": "1408",
+      "tvdb_id": 3021
     },
     {
-      "imdb_id": "nm0001626",
       "type": "Actor",
-      "name": "Christopher Plummer",
-      "tvdb_id": 290
+      "imdb_id": "nm0000131",
+      "tvdb_id": 3036,
+      "name": "John Cusack"
     }
   ]
 }

--- a/puzzles/2023-07-05.json
+++ b/puzzles/2023-07-05.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 449,
-  "target_tvdb_id": 65731,
-  "source_imdb_id": "nm0059431",
-  "target_imdb_id": "nm0941777",
+  "source_tvdb_id": 6161,
+  "target_tvdb_id": 884,
+  "source_imdb_id": "nm0000124",
+  "target_imdb_id": "nm0000114",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0059431",
       "type": "Actor",
-      "name": "Jay Baruchel",
-      "tvdb_id": 449
+      "imdb_id": "nm0000124",
+      "tvdb_id": 6161,
+      "name": "Jennifer Connelly"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0405159",
-      "votes": 698263,
-      "rating": 8.1,
-      "name": "Million Dollar Baby",
-      "tvdb_id": 70
+      "imdb_id": "tt0450259",
+      "votes": 562068,
+      "rating": 8.0,
+      "name": "Blood Diamond",
+      "tvdb_id": 1372
     },
     {
-      "imdb_id": "nm1107001",
       "type": "Actor",
-      "name": "Anthony Mackie",
-      "tvdb_id": 53650
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1568338",
-      "votes": 155207,
-      "rating": 6.6,
-      "name": "Man on a Ledge",
-      "tvdb_id": 49527
+      "imdb_id": "tt0993846",
+      "votes": 1455112,
+      "rating": 8.2,
+      "name": "The Wolf of Wall Street",
+      "tvdb_id": 106646
     },
     {
-      "imdb_id": "nm0941777",
       "type": "Actor",
-      "name": "Sam Worthington",
-      "tvdb_id": 65731
+      "imdb_id": "nm0000114",
+      "tvdb_id": 884,
+      "name": "Steve Buscemi"
     }
   ]
 }

--- a/puzzles/2023-07-06.json
+++ b/puzzles/2023-07-06.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 6383,
-  "target_tvdb_id": 54693,
-  "source_imdb_id": "nm0001173",
-  "target_imdb_id": "nm1297015",
+  "source_tvdb_id": 16483,
+  "target_tvdb_id": 500,
+  "source_imdb_id": "nm0000230",
+  "target_imdb_id": "nm0000129",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0001173",
       "type": "Actor",
-      "name": "Aaron Eckhart",
-      "tvdb_id": 6383
+      "imdb_id": "nm0000230",
+      "tvdb_id": 16483,
+      "name": "Sylvester Stallone"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0427944",
-      "votes": 224830,
-      "rating": 7.5,
-      "name": "Thank You for Smoking",
-      "tvdb_id": 9388
+      "imdb_id": "tt0113492",
+      "votes": 120965,
+      "rating": 5.6,
+      "name": "Judge Dredd",
+      "tvdb_id": 9482
     },
     {
-      "imdb_id": "nm0799777",
       "type": "Actor",
-      "name": "J.K. Simmons",
-      "tvdb_id": 18999
+      "imdb_id": "nm0001884",
+      "tvdb_id": 2201,
+      "name": "Max von Sydow"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3783958",
-      "votes": 612272,
-      "rating": 8.0,
-      "name": "La La Land",
-      "tvdb_id": 313369
+      "imdb_id": "tt0181689",
+      "votes": 563733,
+      "rating": 7.6,
+      "name": "Minority Report",
+      "tvdb_id": 180
     },
     {
-      "imdb_id": "nm1297015",
       "type": "Actor",
-      "name": "Emma Stone",
-      "tvdb_id": 54693
+      "imdb_id": "nm0000129",
+      "tvdb_id": 500,
+      "name": "Tom Cruise"
     }
   ]
 }

--- a/puzzles/2023-07-07.json
+++ b/puzzles/2023-07-07.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 13240,
-  "target_tvdb_id": 4,
-  "source_imdb_id": "nm0000242",
-  "target_imdb_id": "nm0000402",
+  "source_tvdb_id": 3061,
+  "target_tvdb_id": 1158,
+  "source_imdb_id": "nm0000191",
+  "target_imdb_id": "nm0000199",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000242",
       "type": "Actor",
-      "name": "Mark Wahlberg",
-      "tvdb_id": 13240
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0133152",
-      "votes": 223240,
-      "rating": 5.7,
-      "name": "Planet of the Apes",
-      "tvdb_id": 869
+      "imdb_id": "tt0121766",
+      "votes": 808568,
+      "rating": 7.6,
+      "name": "Star Wars: Episode III - Revenge of the Sith",
+      "tvdb_id": 1895
     },
     {
-      "imdb_id": "nm0746989",
       "type": "Actor",
-      "name": "Deep Roy",
-      "tvdb_id": 1295
+      "imdb_id": "nm0000204",
+      "tvdb_id": 524,
+      "name": "Natalie Portman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0080684",
-      "votes": 1316162,
-      "rating": 8.7,
-      "name": "Star Wars: Episode V - The Empire Strikes Back",
-      "tvdb_id": 1891
+      "imdb_id": "tt0113277",
+      "votes": 670703,
+      "rating": 8.3,
+      "name": "Heat",
+      "tvdb_id": 949
     },
     {
-      "imdb_id": "nm0000402",
       "type": "Actor",
-      "name": "Carrie Fisher",
-      "tvdb_id": 4
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
     }
   ]
 }

--- a/puzzles/2023-07-08.json
+++ b/puzzles/2023-07-08.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5576,
-  "target_tvdb_id": 54693,
-  "source_imdb_id": "nm0000174",
-  "target_imdb_id": "nm1297015",
+  "source_tvdb_id": 8289,
+  "target_tvdb_id": 887,
+  "source_imdb_id": "nm0001082",
+  "target_imdb_id": "nm0005562",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000174",
       "type": "Actor",
-      "name": "Val Kilmer",
-      "tvdb_id": 5576
+      "imdb_id": "nm0001082",
+      "tvdb_id": 8289,
+      "name": "Billy Crudup"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1095217",
-      "votes": 78886,
-      "rating": 6.6,
-      "name": "Bad Lieutenant: Port of Call New Orleans",
-      "tvdb_id": 11699
+      "imdb_id": "tt0119698",
+      "votes": 404941,
+      "rating": 8.3,
+      "name": "Princess Mononoke",
+      "tvdb_id": 128
     },
     {
-      "imdb_id": "nm0000115",
       "type": "Actor",
-      "name": "Nicolas Cage",
-      "tvdb_id": 2963
+      "imdb_id": "nm0000671",
+      "tvdb_id": 879,
+      "name": "Billy Bob Thornton"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0481499",
-      "votes": 221696,
-      "rating": 7.2,
-      "name": "The Croods",
-      "tvdb_id": 49519
+      "imdb_id": "tt0120591",
+      "votes": 435147,
+      "rating": 6.7,
+      "name": "Armageddon",
+      "tvdb_id": 95
     },
     {
-      "imdb_id": "nm1297015",
       "type": "Actor",
-      "name": "Emma Stone",
-      "tvdb_id": 54693
+      "imdb_id": "nm0005562",
+      "tvdb_id": 887,
+      "name": "Owen Wilson"
     }
   ]
 }

--- a/puzzles/2023-07-09.json
+++ b/puzzles/2023-07-09.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1328,
-  "target_tvdb_id": 2157,
-  "source_imdb_id": "nm0000276",
-  "target_imdb_id": "nm0000245",
+  "source_tvdb_id": 31,
+  "target_tvdb_id": 44735,
+  "source_imdb_id": "nm0000158",
+  "target_imdb_id": "nm0251986",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000276",
       "type": "Actor",
-      "name": "Sean Astin",
-      "tvdb_id": 1328
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0167261",
-      "votes": 1697780,
-      "rating": 8.8,
-      "name": "The Lord of the Rings: The Two Towers",
-      "tvdb_id": 121
+      "imdb_id": "tt0264464",
+      "votes": 1015683,
+      "rating": 8.1,
+      "name": "Catch Me If You Can",
+      "tvdb_id": 640
     },
     {
-      "imdb_id": "nm0000704",
       "type": "Actor",
-      "name": "Elijah Wood",
-      "tvdb_id": 109
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0366548",
-      "votes": 191970,
+      "imdb_id": "tt2975590",
+      "votes": 710461,
       "rating": 6.4,
-      "name": "Happy Feet",
-      "tvdb_id": 9836
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
     },
     {
-      "imdb_id": "nm0000245",
       "type": "Actor",
-      "name": "Robin Williams",
-      "tvdb_id": 2157
+      "imdb_id": "nm0251986",
+      "tvdb_id": 44735,
+      "name": "Jesse Eisenberg"
     }
   ]
 }

--- a/puzzles/2023-07-10.json
+++ b/puzzles/2023-07-10.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 8167,
-  "target_tvdb_id": 2178,
-  "source_imdb_id": "nm0908094",
-  "target_imdb_id": "nm0001845",
+  "source_tvdb_id": 5294,
+  "target_tvdb_id": 2975,
+  "source_imdb_id": "nm0252230",
+  "target_imdb_id": "nm0000401",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0908094",
       "type": "Actor",
-      "name": "Paul Walker",
-      "tvdb_id": 8167
+      "imdb_id": "nm0252230",
+      "tvdb_id": 5294,
+      "name": "Chiwetel Ejiofor"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1596343",
-      "votes": 389039,
-      "rating": 7.3,
-      "name": "Fast Five",
-      "tvdb_id": 51497
+      "imdb_id": "tt2024544",
+      "votes": 713888,
+      "rating": 8.1,
+      "name": "12 Years a Slave",
+      "tvdb_id": 76203
     },
     {
-      "imdb_id": "nm0176085",
       "type": "Actor",
-      "name": "Yorgo Constantine",
-      "tvdb_id": 21051
+      "imdb_id": "nm1058940",
+      "tvdb_id": 59233,
+      "name": "Scoot McNairy"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0183649",
-      "votes": 275592,
-      "rating": 7.1,
-      "name": "Phone Booth",
-      "tvdb_id": 1817
+      "imdb_id": "tt2975590",
+      "votes": 710461,
+      "rating": 6.4,
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
     },
     {
-      "imdb_id": "nm0001845",
       "type": "Actor",
-      "name": "Forest Whitaker",
-      "tvdb_id": 2178
+      "imdb_id": "nm0000401",
+      "tvdb_id": 2975,
+      "name": "Laurence Fishburne"
     }
   ]
 }

--- a/puzzles/2023-07-11.json
+++ b/puzzles/2023-07-11.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2228,
-  "target_tvdb_id": 6161,
-  "source_imdb_id": "nm0000576",
-  "target_imdb_id": "nm0000124",
+  "source_tvdb_id": 19292,
+  "target_tvdb_id": 12835,
+  "source_imdb_id": "nm0001191",
+  "target_imdb_id": "nm0004874",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000576",
       "type": "Actor",
-      "name": "Sean Penn",
-      "tvdb_id": 2228
+      "imdb_id": "nm0001191",
+      "tvdb_id": 19292,
+      "name": "Adam Sandler"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0086200",
-      "votes": 94920,
-      "rating": 6.8,
-      "name": "Risky Business",
-      "tvdb_id": 9346
+      "imdb_id": "tt1564367",
+      "votes": 252391,
+      "rating": 6.4,
+      "name": "Just Go with It",
+      "tvdb_id": 50546
     },
     {
-      "imdb_id": "nm0000129",
       "type": "Actor",
-      "name": "Tom Cruise",
-      "tvdb_id": 500
+      "imdb_id": "nm0000098",
+      "tvdb_id": 4491,
+      "name": "Jennifer Aniston"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1745960",
-      "votes": 577408,
-      "rating": 8.3,
-      "name": "Top Gun: Maverick",
-      "tvdb_id": 361743
+      "imdb_id": "tt0129167",
+      "votes": 207625,
+      "rating": 8.1,
+      "name": "The Iron Giant",
+      "tvdb_id": 10386
     },
     {
-      "imdb_id": "nm0000124",
       "type": "Actor",
-      "name": "Jennifer Connelly",
-      "tvdb_id": 6161
+      "imdb_id": "nm0004874",
+      "tvdb_id": 12835,
+      "name": "Vin Diesel"
     }
   ]
 }

--- a/puzzles/2023-07-12.json
+++ b/puzzles/2023-07-12.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4483,
-  "target_tvdb_id": 3967,
-  "source_imdb_id": "nm0000163",
-  "target_imdb_id": "nm0000295",
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 2461,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0000154",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000163",
       "type": "Actor",
-      "name": "Dustin Hoffman",
-      "tvdb_id": 4483
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2267968",
-      "votes": 168500,
-      "rating": 7.1,
-      "name": "Kung Fu Panda 3",
-      "tvdb_id": 140300
+      "imdb_id": "tt1156398",
+      "votes": 593204,
+      "rating": 7.6,
+      "name": "Zombieland",
+      "tvdb_id": 19908
     },
     {
-      "imdb_id": "nm0186505",
       "type": "Actor",
-      "name": "Bryan Cranston",
-      "tvdb_id": 17419
+      "imdb_id": "nm1113550",
+      "tvdb_id": 17140,
+      "name": "Abigail Breslin"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1386703",
-      "votes": 259277,
-      "rating": 6.2,
-      "name": "Total Recall",
-      "tvdb_id": 64635
+      "imdb_id": "tt0286106",
+      "votes": 371970,
+      "rating": 6.8,
+      "name": "Signs",
+      "tvdb_id": 2675
     },
     {
-      "imdb_id": "nm0000295",
       "type": "Actor",
-      "name": "Kate Beckinsale",
-      "tvdb_id": 3967
+      "imdb_id": "nm0000154",
+      "tvdb_id": 2461,
+      "name": "Mel Gibson"
     }
   ]
 }

--- a/puzzles/2023-07-13.json
+++ b/puzzles/2023-07-13.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 368,
-  "target_tvdb_id": 7060,
-  "source_imdb_id": "nm0000702",
-  "target_imdb_id": "nm0293509",
+  "source_tvdb_id": 3,
+  "target_tvdb_id": 72466,
+  "source_imdb_id": "nm0000148",
+  "target_imdb_id": "nm0268199",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000702",
       "type": "Actor",
-      "name": "Reese Witherspoon",
-      "tvdb_id": 368
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1596350",
-      "votes": 190062,
-      "rating": 6.3,
-      "name": "This Means War",
-      "tvdb_id": 59962
+      "imdb_id": "tt2488496",
+      "votes": 944891,
+      "rating": 7.8,
+      "name": "Star Wars: Episode VII - The Force Awakens",
+      "tvdb_id": 140607
     },
     {
-      "imdb_id": "nm0000291",
       "type": "Actor",
-      "name": "Angela Bassett",
-      "tvdb_id": 9780
+      "imdb_id": "nm0785227",
+      "tvdb_id": 1333,
+      "name": "Andy Serkis"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1825683",
-      "votes": 798599,
-      "rating": 7.3,
-      "name": "Black Panther",
-      "tvdb_id": 284054
+      "imdb_id": "tt1877830",
+      "votes": 694643,
+      "rating": 7.8,
+      "name": "The Batman",
+      "tvdb_id": 414906
     },
     {
-      "imdb_id": "nm0293509",
       "type": "Actor",
-      "name": "Martin Freeman",
-      "tvdb_id": 7060
+      "imdb_id": "nm0268199",
+      "tvdb_id": 72466,
+      "name": "Colin Farrell"
     }
   ]
 }

--- a/puzzles/2023-07-14.json
+++ b/puzzles/2023-07-14.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2282,
-  "target_tvdb_id": 4517,
-  "source_imdb_id": "nm0001426",
-  "target_imdb_id": "nm0000582",
+  "source_tvdb_id": 62064,
+  "target_tvdb_id": 48,
+  "source_imdb_id": "nm1517976",
+  "target_imdb_id": "nm0000293",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0001426",
       "type": "Actor",
-      "name": "Ben Kingsley",
-      "tvdb_id": 2282
+      "imdb_id": "nm1517976",
+      "tvdb_id": 62064,
+      "name": "Chris Pine"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1130884",
-      "votes": 1353782,
-      "rating": 8.2,
-      "name": "Shutter Island",
-      "tvdb_id": 11324
+      "imdb_id": "tt0796366",
+      "votes": 609483,
+      "rating": 7.9,
+      "name": "Star Trek",
+      "tvdb_id": 13475
     },
     {
-      "imdb_id": "nm0717518",
       "type": "Actor",
-      "name": "Joseph P. Reidy",
-      "tvdb_id": 7531
+      "imdb_id": "nm0881631",
+      "tvdb_id": 1372,
+      "name": "Karl Urban"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0112641",
-      "votes": 532516,
-      "rating": 8.2,
-      "name": "Casino",
-      "tvdb_id": 524
+      "imdb_id": "tt0167260",
+      "votes": 1880701,
+      "rating": 9.0,
+      "name": "The Lord of the Rings: The Return of the King",
+      "tvdb_id": 122
     },
     {
-      "imdb_id": "nm0000582",
       "type": "Actor",
-      "name": "Joe Pesci",
-      "tvdb_id": 4517
+      "imdb_id": "nm0000293",
+      "tvdb_id": 48,
+      "name": "Sean Bean"
     }
   ]
 }

--- a/puzzles/2023-07-15.json
+++ b/puzzles/2023-07-15.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5081,
-  "target_tvdb_id": 17178,
-  "source_imdb_id": "nm1289434",
-  "target_imdb_id": "nm0933940",
+  "source_tvdb_id": 2178,
+  "target_tvdb_id": 2283,
+  "source_imdb_id": "nm0001845",
+  "target_imdb_id": "nm0001804",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm1289434",
       "type": "Actor",
-      "name": "Emily Blunt",
-      "tvdb_id": 5081
+      "imdb_id": "nm0001845",
+      "tvdb_id": 2178,
+      "name": "Forest Whitaker"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2381991",
-      "votes": 113813,
-      "rating": 6.1,
-      "name": "The Huntsman: Winter's War",
-      "tvdb_id": 290595
+      "imdb_id": "tt2543164",
+      "votes": 715446,
+      "rating": 7.9,
+      "name": "Arrival",
+      "tvdb_id": 329865
     },
     {
-      "imdb_id": "nm0000234",
       "type": "Actor",
-      "name": "Charlize Theron",
-      "tvdb_id": 6885
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1446714",
-      "votes": 620211,
+      "imdb_id": "tt1135503",
+      "votes": 123724,
       "rating": 7.0,
-      "name": "Prometheus",
-      "tvdb_id": 70981
+      "name": "Julie & Julia",
+      "tvdb_id": 24803
     },
     {
-      "imdb_id": "nm0933940",
       "type": "Actor",
-      "name": "Patrick Wilson",
-      "tvdb_id": 17178
+      "imdb_id": "nm0001804",
+      "tvdb_id": 2283,
+      "name": "Stanley Tucci"
     }
   ]
 }

--- a/puzzles/2023-07-16.json
+++ b/puzzles/2023-07-16.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18918,
-  "target_tvdb_id": 569,
-  "source_imdb_id": "nm0425005",
-  "target_imdb_id": "nm0000160",
+  "source_tvdb_id": 23659,
+  "target_tvdb_id": 16483,
+  "source_imdb_id": "nm0002071",
+  "target_imdb_id": "nm0000230",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0425005",
       "type": "Actor",
-      "name": "Dwayne Johnson",
-      "tvdb_id": 18918
+      "imdb_id": "nm0002071",
+      "tvdb_id": 23659,
+      "name": "Will Ferrell"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1433108",
-      "votes": 109638,
-      "rating": 6.4,
-      "name": "Faster",
-      "tvdb_id": 41283
-    },
-    {
-      "imdb_id": "nm0000297",
-      "type": "Actor",
-      "name": "Tom Berenger",
-      "tvdb_id": 13022
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt0139654",
-      "votes": 448538,
+      "imdb_id": "tt1490017",
+      "votes": 366969,
       "rating": 7.7,
-      "name": "Training Day",
-      "tvdb_id": 2034
+      "name": "The Lego Movie",
+      "tvdb_id": 137106
     },
     {
-      "imdb_id": "nm0000160",
       "type": "Actor",
-      "name": "Ethan Hawke",
-      "tvdb_id": 569
+      "imdb_id": "nm0695435",
+      "tvdb_id": 73457,
+      "name": "Chris Pratt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3896198",
+      "votes": 700926,
+      "rating": 7.6,
+      "name": "Guardians of the Galaxy Vol. 2",
+      "tvdb_id": 283995
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000230",
+      "tvdb_id": 16483,
+      "name": "Sylvester Stallone"
     }
   ]
 }

--- a/puzzles/2023-07-17.json
+++ b/puzzles/2023-07-17.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1230,
-  "target_tvdb_id": 8167,
-  "source_imdb_id": "nm0000422",
-  "target_imdb_id": "nm0908094",
+  "source_tvdb_id": 7399,
+  "target_tvdb_id": 6856,
+  "source_imdb_id": "nm0001774",
+  "target_imdb_id": "nm0000621",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000422",
       "type": "Actor",
-      "name": "John Goodman",
-      "tvdb_id": 1230
+      "imdb_id": "nm0001774",
+      "tvdb_id": 7399,
+      "name": "Ben Stiller"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3731562",
-      "votes": 328607,
-      "rating": 6.6,
-      "name": "Kong: Skull Island",
-      "tvdb_id": 293167
+      "imdb_id": "tt0129387",
+      "votes": 318188,
+      "rating": 7.1,
+      "name": "There's Something About Mary",
+      "tvdb_id": 544
     },
     {
-      "imdb_id": "nm0651159",
       "type": "Actor",
-      "name": "John Ortiz",
-      "tvdb_id": 40543
+      "imdb_id": "nm0000139",
+      "tvdb_id": 6941,
+      "name": "Cameron Diaz"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1013752",
-      "votes": 294626,
-      "rating": 6.5,
-      "name": "Fast & Furious",
-      "tvdb_id": 13804
+      "imdb_id": "tt0259711",
+      "votes": 275152,
+      "rating": 6.9,
+      "name": "Vanilla Sky",
+      "tvdb_id": 1903
     },
     {
-      "imdb_id": "nm0908094",
       "type": "Actor",
-      "name": "Paul Walker",
-      "tvdb_id": 8167
+      "imdb_id": "nm0000621",
+      "tvdb_id": 6856,
+      "name": "Kurt Russell"
     }
   ]
 }

--- a/puzzles/2023-07-18.json
+++ b/puzzles/2023-07-18.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4783,
-  "target_tvdb_id": 193,
-  "source_imdb_id": "nm0000554",
-  "target_imdb_id": "nm0000432",
+  "source_tvdb_id": 12835,
+  "target_tvdb_id": 38673,
+  "source_imdb_id": "nm0004874",
+  "target_imdb_id": "nm1475594",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000554",
       "type": "Actor",
-      "name": "Sam Neill",
-      "tvdb_id": 4783
+      "imdb_id": "nm0004874",
+      "tvdb_id": 12835,
+      "name": "Vin Diesel"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107290",
-      "votes": 1010271,
-      "rating": 8.2,
-      "name": "Jurassic Park",
-      "tvdb_id": 329
+      "imdb_id": "tt1905041",
+      "votes": 401504,
+      "rating": 7.0,
+      "name": "Fast & Furious 6",
+      "tvdb_id": 82992
     },
     {
-      "imdb_id": "nm0274684",
       "type": "Actor",
-      "name": "Martin Ferrero",
-      "tvdb_id": 4790
+      "imdb_id": "nm0425005",
+      "tvdb_id": 18918,
+      "name": "Dwayne Johnson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0113161",
-      "votes": 85938,
-      "rating": 6.9,
-      "name": "Get Shorty",
-      "tvdb_id": 8012
+      "imdb_id": "tt1583421",
+      "votes": 184006,
+      "rating": 5.7,
+      "name": "G.I. Joe: Retaliation",
+      "tvdb_id": 72559
     },
     {
-      "imdb_id": "nm0000432",
       "type": "Actor",
-      "name": "Gene Hackman",
-      "tvdb_id": 193
+      "imdb_id": "nm1475594",
+      "tvdb_id": 38673,
+      "name": "Channing Tatum"
     }
   ]
 }

--- a/puzzles/2023-07-19.json
+++ b/puzzles/2023-07-19.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 6384,
-  "target_tvdb_id": 854,
-  "source_imdb_id": "nm0000206",
-  "target_imdb_id": "nm0000071",
+  "source_tvdb_id": 71580,
+  "target_tvdb_id": 514,
+  "source_imdb_id": "nm1212722",
+  "target_imdb_id": "nm0000197",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000206",
       "type": "Actor",
-      "name": "Keanu Reeves",
-      "tvdb_id": 6384
+      "imdb_id": "nm1212722",
+      "tvdb_id": 71580,
+      "name": "Benedict Cumberbatch"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0111257",
-      "votes": 374742,
-      "rating": 7.3,
-      "name": "Speed",
-      "tvdb_id": 1637
+      "imdb_id": "tt3501632",
+      "votes": 771855,
+      "rating": 7.9,
+      "name": "Thor: Ragnarok",
+      "tvdb_id": 284053
     },
     {
-      "imdb_id": "nm0687625",
       "type": "Actor",
-      "name": "Glenn Plummer",
-      "tvdb_id": 2683
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
     },
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm0000197",
+      "tvdb_id": 514,
+      "name": "Jack Nicholson"
     }
   ]
 }

--- a/puzzles/2023-07-20.json
+++ b/puzzles/2023-07-20.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 18269,
-  "target_tvdb_id": 173431,
-  "source_imdb_id": "nm0000409",
-  "target_imdb_id": "nm0021600",
+  "source_tvdb_id": 7447,
+  "target_tvdb_id": 2283,
+  "source_imdb_id": "nm0000285",
+  "target_imdb_id": "nm0001804",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000409",
       "type": "Actor",
-      "name": "Brendan Fraser",
-      "tvdb_id": 18269
+      "imdb_id": "nm0000285",
+      "tvdb_id": 7447,
+      "name": "Alec Baldwin"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0494238",
-      "votes": 80105,
-      "rating": 6.1,
-      "name": "Inkheart",
-      "tvdb_id": 2309
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
     },
     {
-      "imdb_id": "nm0785227",
       "type": "Actor",
-      "name": "Andy Serkis",
-      "tvdb_id": 1333
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0167261",
-      "votes": 1697780,
-      "rating": 8.8,
-      "name": "The Lord of the Rings: The Two Towers",
-      "tvdb_id": 121
+      "imdb_id": "tt2109248",
+      "votes": 319961,
+      "rating": 5.6,
+      "name": "Transformers: Age of Extinction",
+      "tvdb_id": 91314
     },
     {
-      "imdb_id": "nm0021600",
       "type": "Actor",
-      "name": "Bruce Allpress",
-      "tvdb_id": 173431
+      "imdb_id": "nm0001804",
+      "tvdb_id": 2283,
+      "name": "Stanley Tucci"
     }
   ]
 }

--- a/puzzles/2023-07-21.json
+++ b/puzzles/2023-07-21.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 193,
-  "target_tvdb_id": 5472,
-  "source_imdb_id": "nm0000432",
-  "target_imdb_id": "nm0000147",
+  "source_tvdb_id": 2157,
+  "target_tvdb_id": 51329,
+  "source_imdb_id": "nm0000245",
+  "target_imdb_id": "nm0177896",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000432",
       "type": "Actor",
-      "name": "Gene Hackman",
-      "tvdb_id": 193
+      "imdb_id": "nm0000245",
+      "tvdb_id": 2157,
+      "name": "Robin Williams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0095647",
-      "votes": 103970,
+      "imdb_id": "tt0099077",
+      "votes": 148174,
       "rating": 7.8,
-      "name": "Mississippi Burning",
-      "tvdb_id": 1632
+      "name": "Awakenings",
+      "tvdb_id": 11005
     },
     {
-      "imdb_id": "nm0000353",
       "type": "Actor",
-      "name": "Willem Dafoe",
-      "tvdb_id": 5293
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0116209",
-      "votes": 194559,
-      "rating": 7.4,
-      "name": "The English Patient",
-      "tvdb_id": 409
+      "imdb_id": "tt1045658",
+      "votes": 720058,
+      "rating": 7.7,
+      "name": "Silver Linings Playbook",
+      "tvdb_id": 82693
     },
     {
-      "imdb_id": "nm0000147",
       "type": "Actor",
-      "name": "Colin Firth",
-      "tvdb_id": 5472
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
     }
   ]
 }

--- a/puzzles/2023-07-22.json
+++ b/puzzles/2023-07-22.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2283,
-  "target_tvdb_id": 776,
-  "source_imdb_id": "nm0001804",
-  "target_imdb_id": "nm0000552",
+  "source_tvdb_id": 5293,
+  "target_tvdb_id": 4173,
+  "source_imdb_id": "nm0000353",
+  "target_imdb_id": "nm0000164",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0001804",
       "type": "Actor",
-      "name": "Stanley Tucci",
-      "tvdb_id": 2283
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0362227",
-      "votes": 471100,
-      "rating": 7.4,
-      "name": "The Terminal",
-      "tvdb_id": 594
+      "imdb_id": "tt2278388",
+      "votes": 834412,
+      "rating": 8.1,
+      "name": "The Grand Budapest Hotel",
+      "tvdb_id": 120467
     },
     {
-      "imdb_id": "nm0377106",
       "type": "Actor",
-      "name": "Barry Shabaka Henley",
-      "tvdb_id": 8689
+      "imdb_id": "nm0000146",
+      "tvdb_id": 5469,
+      "name": "Ralph Fiennes"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0123964",
-      "votes": 52710,
-      "rating": 6.8,
-      "name": "Life",
-      "tvdb_id": 6522
+      "imdb_id": "tt0289765",
+      "votes": 280472,
+      "rating": 7.2,
+      "name": "Red Dragon",
+      "tvdb_id": 9533
     },
     {
-      "imdb_id": "nm0000552",
       "type": "Actor",
-      "name": "Eddie Murphy",
-      "tvdb_id": 776
+      "imdb_id": "nm0000164",
+      "tvdb_id": 4173,
+      "name": "Anthony Hopkins"
     }
   ]
 }

--- a/puzzles/2023-07-23.json
+++ b/puzzles/2023-07-23.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5472,
-  "target_tvdb_id": 190,
-  "source_imdb_id": "nm0000147",
-  "target_imdb_id": "nm0000142",
+  "source_tvdb_id": 10980,
+  "target_tvdb_id": 934,
+  "source_imdb_id": "nm0705356",
+  "target_imdb_id": "nm0000128",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000147",
       "type": "Actor",
-      "name": "Colin Firth",
-      "tvdb_id": 5472
+      "imdb_id": "nm0705356",
+      "tvdb_id": 10980,
+      "name": "Daniel Radcliffe"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0116209",
-      "votes": 194559,
-      "rating": 7.4,
-      "name": "The English Patient",
-      "tvdb_id": 409
+      "imdb_id": "tt0241527",
+      "votes": 806134,
+      "rating": 7.6,
+      "name": "Harry Potter and the Sorcerer's Stone",
+      "tvdb_id": 671
     },
     {
-      "imdb_id": "nm0720082",
       "type": "Actor",
-      "name": "Liisa Repo-Martell",
-      "tvdb_id": 5481
+      "imdb_id": "nm0001321",
+      "tvdb_id": 194,
+      "name": "Richard Harris"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0105695",
-      "votes": 419562,
-      "rating": 8.2,
-      "name": "Unforgiven",
-      "tvdb_id": 33
+      "imdb_id": "tt0172495",
+      "votes": 1530321,
+      "rating": 8.5,
+      "name": "Gladiator",
+      "tvdb_id": 98
     },
     {
-      "imdb_id": "nm0000142",
       "type": "Actor",
-      "name": "Clint Eastwood",
-      "tvdb_id": 190
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
     }
   ]
 }

--- a/puzzles/2023-07-24.json
+++ b/puzzles/2023-07-24.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4491,
-  "target_tvdb_id": 118,
-  "source_imdb_id": "nm0000098",
-  "target_imdb_id": "nm0001691",
+  "source_tvdb_id": 24045,
+  "target_tvdb_id": 16828,
+  "source_imdb_id": "nm0330687",
+  "target_imdb_id": "nm0262635",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000098",
       "type": "Actor",
-      "name": "Jennifer Aniston",
-      "tvdb_id": 4491
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0151804",
-      "votes": 274610,
-      "rating": 7.6,
-      "name": "Office Space",
-      "tvdb_id": 1542
+      "imdb_id": "tt2229499",
+      "votes": 242723,
+      "rating": 6.5,
+      "name": "Don Jon",
+      "tvdb_id": 138697
     },
     {
-      "imdb_id": "nm0740535",
       "type": "Actor",
-      "name": "Stephen Root",
-      "tvdb_id": 17401
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0266543",
-      "votes": 1062914,
-      "rating": 8.2,
-      "name": "Finding Nemo",
-      "tvdb_id": 12
+      "imdb_id": "tt1843866",
+      "votes": 862951,
+      "rating": 7.8,
+      "name": "Captain America: The Winter Soldier",
+      "tvdb_id": 100402
     },
     {
-      "imdb_id": "nm0001691",
       "type": "Actor",
-      "name": "Geoffrey Rush",
-      "tvdb_id": 118
+      "imdb_id": "nm0262635",
+      "tvdb_id": 16828,
+      "name": "Chris Evans"
     }
   ]
 }

--- a/puzzles/2023-07-25.json
+++ b/puzzles/2023-07-25.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2228,
-  "target_tvdb_id": 7060,
-  "source_imdb_id": "nm0000576",
-  "target_imdb_id": "nm0293509",
+  "source_tvdb_id": 11108,
+  "target_tvdb_id": 206,
+  "source_imdb_id": "nm0670408",
+  "target_imdb_id": "nm0000120",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000576",
       "type": "Actor",
-      "name": "Sean Penn",
-      "tvdb_id": 2228
+      "imdb_id": "nm0670408",
+      "tvdb_id": 11108,
+      "name": "Simon Pegg"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0327056",
-      "votes": 466393,
-      "rating": 7.9,
-      "name": "Mystic River",
-      "tvdb_id": 322
+      "imdb_id": "tt1229238",
+      "votes": 500030,
+      "rating": 7.4,
+      "name": "Mission: Impossible - Ghost Protocol",
+      "tvdb_id": 56292
     },
     {
-      "imdb_id": "nm0001473",
       "type": "Actor",
-      "name": "Laura Linney",
-      "tvdb_id": 350
+      "imdb_id": "nm0929489",
+      "tvdb_id": 207,
+      "name": "Tom Wilkinson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0314331",
-      "votes": 502629,
-      "rating": 7.6,
-      "name": "Love Actually",
-      "tvdb_id": 508
+      "imdb_id": "tt0338013",
+      "votes": 1027917,
+      "rating": 8.3,
+      "name": "Eternal Sunshine of the Spotless Mind",
+      "tvdb_id": 38
     },
     {
-      "imdb_id": "nm0293509",
       "type": "Actor",
-      "name": "Martin Freeman",
-      "tvdb_id": 7060
+      "imdb_id": "nm0000120",
+      "tvdb_id": 206,
+      "name": "Jim Carrey"
     }
   ]
 }

--- a/puzzles/2023-07-26.json
+++ b/puzzles/2023-07-26.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 27428,
-  "target_tvdb_id": 19292,
-  "source_imdb_id": "nm1093951",
-  "target_imdb_id": "nm0001191",
+  "source_tvdb_id": 18277,
+  "target_tvdb_id": 17288,
+  "source_imdb_id": "nm0000113",
+  "target_imdb_id": "nm1055413",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm1093951",
       "type": "Actor",
-      "name": "Aaron Taylor-Johnson",
-      "tvdb_id": 27428
+      "imdb_id": "nm0000113",
+      "tvdb_id": 18277,
+      "name": "Sandra Bullock"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0443543",
-      "votes": 379380,
-      "rating": 7.5,
-      "name": "The Illusionist",
-      "tvdb_id": 1491
+      "imdb_id": "tt12593682",
+      "votes": 348287,
+      "rating": 7.3,
+      "name": "Bullet Train",
+      "tvdb_id": 718930
     },
     {
-      "imdb_id": "nm0004754",
       "type": "Actor",
-      "name": "Jessica Biel",
-      "tvdb_id": 10860
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0762107",
-      "votes": 150279,
-      "rating": 5.9,
-      "name": "I Now Pronounce You Chuck & Larry",
-      "tvdb_id": 3563
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
     },
     {
-      "imdb_id": "nm0001191",
       "type": "Actor",
-      "name": "Adam Sandler",
-      "tvdb_id": 19292
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
     }
   ]
 }

--- a/puzzles/2023-07-27.json
+++ b/puzzles/2023-07-27.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1204,
-  "target_tvdb_id": 3087,
-  "source_imdb_id": "nm0000210",
-  "target_imdb_id": "nm0000380",
+  "source_tvdb_id": 1461,
+  "target_tvdb_id": 73968,
+  "source_imdb_id": "nm0000123",
+  "target_imdb_id": "nm0147147",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000210",
       "type": "Actor",
-      "name": "Julia Roberts",
-      "tvdb_id": 1204
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0163187",
-      "votes": 101035,
-      "rating": 5.6,
-      "name": "Runaway Bride",
-      "tvdb_id": 4806
+      "imdb_id": "tt0177971",
+      "votes": 172062,
+      "rating": 6.5,
+      "name": "The Perfect Storm",
+      "tvdb_id": 2133
     },
     {
-      "imdb_id": "nm0556985",
       "type": "Actor",
-      "name": "Tom Mason",
-      "tvdb_id": 80874
+      "imdb_id": "nm0000178",
+      "tvdb_id": 2882,
+      "name": "Diane Lane"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0078788",
-      "votes": 680101,
-      "rating": 8.5,
-      "name": "Apocalypse Now",
-      "tvdb_id": 28
+      "imdb_id": "tt0770828",
+      "votes": 784138,
+      "rating": 7.1,
+      "name": "Man of Steel",
+      "tvdb_id": 49521
     },
     {
-      "imdb_id": "nm0000380",
       "type": "Actor",
-      "name": "Robert Duvall",
-      "tvdb_id": 3087
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
     }
   ]
 }

--- a/puzzles/2023-07-28.json
+++ b/puzzles/2023-07-28.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 114,
-  "target_tvdb_id": 21657,
-  "source_imdb_id": "nm0089217",
-  "target_imdb_id": "nm0267812",
+  "source_tvdb_id": 192,
+  "target_tvdb_id": 18269,
+  "source_imdb_id": "nm0000151",
+  "target_imdb_id": "nm0000409",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0089217",
       "type": "Actor",
-      "name": "Orlando Bloom",
-      "tvdb_id": 114
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0368709",
-      "votes": 71360,
-      "rating": 6.3,
-      "name": "Elizabethtown",
-      "tvdb_id": 9621
+      "imdb_id": "tt0114369",
+      "votes": 1690351,
+      "rating": 8.6,
+      "name": "Se7en",
+      "tvdb_id": 807
     },
     {
-      "imdb_id": "nm0000285",
       "type": "Actor",
-      "name": "Alec Baldwin",
-      "tvdb_id": 7447
+      "imdb_id": "nm0745780",
+      "tvdb_id": 6487,
+      "name": "Richard Roundtree"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0407887",
-      "votes": 1351191,
-      "rating": 8.5,
-      "name": "The Departed",
-      "tvdb_id": 1422
+      "imdb_id": "tt0119190",
+      "votes": 81411,
+      "rating": 5.5,
+      "name": "George of the Jungle",
+      "tvdb_id": 10603
     },
     {
-      "imdb_id": "nm0267812",
       "type": "Actor",
-      "name": "Vera Farmiga",
-      "tvdb_id": 21657
+      "imdb_id": "nm0000409",
+      "tvdb_id": 18269,
+      "name": "Brendan Fraser"
     }
   ]
 }

--- a/puzzles/2023-07-29.json
+++ b/puzzles/2023-07-29.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 6730,
-  "target_tvdb_id": 854,
-  "source_imdb_id": "nm0056187",
-  "target_imdb_id": "nm0000071",
+  "source_tvdb_id": 190,
+  "target_tvdb_id": 38673,
+  "source_imdb_id": "nm0000142",
+  "target_imdb_id": "nm1475594",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0056187",
       "type": "Actor",
-      "name": "Sacha Baron Cohen",
-      "tvdb_id": 6730
+      "imdb_id": "nm0000142",
+      "tvdb_id": 190,
+      "name": "Clint Eastwood"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0351283",
-      "votes": 415954,
-      "rating": 6.9,
-      "name": "Madagascar",
-      "tvdb_id": 953
+      "imdb_id": "tt0405159",
+      "votes": 698263,
+      "rating": 8.1,
+      "name": "Million Dollar Baby",
+      "tvdb_id": 70
     },
     {
-      "imdb_id": "nm0000586",
       "type": "Actor",
-      "name": "Jada Pinkett Smith",
-      "tvdb_id": 9575
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0107554",
-      "votes": 61419,
-      "rating": 7.5,
-      "name": "Menace II Society",
-      "tvdb_id": 9516
+      "imdb_id": "tt1245492",
+      "votes": 421307,
+      "rating": 6.6,
+      "name": "This Is the End",
+      "tvdb_id": 109414
     },
     {
-      "imdb_id": "nm0000071",
       "type": "Actor",
-      "name": "James Stewart",
-      "tvdb_id": 854
+      "imdb_id": "nm1475594",
+      "tvdb_id": 38673,
+      "name": "Channing Tatum"
     }
   ]
 }

--- a/puzzles/2023-07-30.json
+++ b/puzzles/2023-07-30.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 10959,
-  "target_tvdb_id": 4517,
-  "source_imdb_id": "nm0479471",
-  "target_imdb_id": "nm0000582",
+  "source_tvdb_id": 1100,
+  "target_tvdb_id": 6730,
+  "source_imdb_id": "nm0000216",
+  "target_imdb_id": "nm0056187",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0479471",
       "type": "Actor",
-      "name": "Shia LaBeouf",
-      "tvdb_id": 10959
+      "imdb_id": "nm0000216",
+      "tvdb_id": 1100,
+      "name": "Arnold Schwarzenegger"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0423294",
-      "votes": 84152,
-      "rating": 6.7,
-      "name": "Surf's Up",
-      "tvdb_id": 9408
+      "imdb_id": "tt0111503",
+      "votes": 267795,
+      "rating": 7.3,
+      "name": "True Lies",
+      "tvdb_id": 36955
     },
     {
-      "imdb_id": "nm0000249",
       "type": "Actor",
-      "name": "James Woods",
-      "tvdb_id": 4512
+      "imdb_id": "nm0046223",
+      "tvdb_id": 173810,
+      "name": "Sayed Badreya"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0112641",
-      "votes": 532516,
-      "rating": 8.2,
-      "name": "Casino",
-      "tvdb_id": 524
+      "imdb_id": "tt1645170",
+      "votes": 317452,
+      "rating": 6.4,
+      "name": "The Dictator",
+      "tvdb_id": 76493
     },
     {
-      "imdb_id": "nm0000582",
       "type": "Actor",
-      "name": "Joe Pesci",
-      "tvdb_id": 4517
+      "imdb_id": "nm0056187",
+      "tvdb_id": 6730,
+      "name": "Sacha Baron Cohen"
     }
   ]
 }

--- a/puzzles/2023-07-31.json
+++ b/puzzles/2023-07-31.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 11108,
-  "target_tvdb_id": 12073,
-  "source_imdb_id": "nm0670408",
-  "target_imdb_id": "nm0000196",
+  "source_tvdb_id": 880,
+  "target_tvdb_id": 569,
+  "source_imdb_id": "nm0000255",
+  "target_imdb_id": "nm0000160",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0670408",
       "type": "Actor",
-      "name": "Simon Pegg",
-      "tvdb_id": 11108
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1229238",
-      "votes": 500030,
-      "rating": 7.4,
-      "name": "Mission: Impossible - Ghost Protocol",
-      "tvdb_id": 56292
+      "imdb_id": "tt0119217",
+      "votes": 998916,
+      "rating": 8.3,
+      "name": "Good Will Hunting",
+      "tvdb_id": 489
     },
     {
-      "imdb_id": "nm0000129",
       "type": "Actor",
-      "name": "Tom Cruise",
-      "tvdb_id": 500
+      "imdb_id": "nm0000245",
+      "tvdb_id": 2157,
+      "name": "Robin Williams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0295178",
-      "votes": 215087,
-      "rating": 6.2,
-      "name": "Austin Powers in Goldmember",
-      "tvdb_id": 818
+      "imdb_id": "tt0097165",
+      "votes": 507205,
+      "rating": 8.1,
+      "name": "Dead Poets Society",
+      "tvdb_id": 207
     },
     {
-      "imdb_id": "nm0000196",
       "type": "Actor",
-      "name": "Mike Myers",
-      "tvdb_id": 12073
+      "imdb_id": "nm0000160",
+      "tvdb_id": 569,
+      "name": "Ethan Hawke"
     }
   ]
 }

--- a/puzzles/2023-08-01.json
+++ b/puzzles/2023-08-01.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 139,
-  "target_tvdb_id": 17051,
-  "source_imdb_id": "nm0000235",
-  "target_imdb_id": "nm0290556",
+  "source_tvdb_id": 44735,
+  "target_tvdb_id": 5081,
+  "source_imdb_id": "nm0251986",
+  "target_imdb_id": "nm1289434",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000235",
       "type": "Actor",
-      "name": "Uma Thurman",
-      "tvdb_id": 139
+      "imdb_id": "nm0251986",
+      "tvdb_id": 44735,
+      "name": "Jesse Eisenberg"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0110912",
-      "votes": 2101050,
-      "rating": 8.9,
-      "name": "Pulp Fiction",
-      "tvdb_id": 680
+      "imdb_id": "tt1670345",
+      "votes": 676146,
+      "rating": 7.2,
+      "name": "Now You See Me",
+      "tvdb_id": 75656
     },
     {
-      "imdb_id": "nm0482851",
       "type": "Actor",
-      "name": "Phil LaMarr",
-      "tvdb_id": 31549
+      "imdb_id": "nm0446672",
+      "tvdb_id": 50217,
+      "name": "Michael Kelly"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0316654",
-      "votes": 669481,
-      "rating": 7.4,
-      "name": "Spider-Man 2",
-      "tvdb_id": 558
+      "imdb_id": "tt1385826",
+      "votes": 262122,
+      "rating": 7.0,
+      "name": "The Adjustment Bureau",
+      "tvdb_id": 38050
     },
     {
-      "imdb_id": "nm0290556",
       "type": "Actor",
-      "name": "James Franco",
-      "tvdb_id": 17051
+      "imdb_id": "nm1289434",
+      "tvdb_id": 5081,
+      "name": "Emily Blunt"
     }
   ]
 }

--- a/puzzles/2023-08-02.json
+++ b/puzzles/2023-08-02.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 5292,
-  "target_tvdb_id": 530,
-  "source_imdb_id": "nm0000243",
-  "target_imdb_id": "nm0005251",
+  "source_tvdb_id": 65731,
+  "target_tvdb_id": 190,
+  "source_imdb_id": "nm0941777",
+  "target_imdb_id": "nm0000142",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000243",
       "type": "Actor",
-      "name": "Denzel Washington",
-      "tvdb_id": 5292
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0455944",
-      "votes": 382725,
-      "rating": 7.2,
-      "name": "The Equalizer",
-      "tvdb_id": 156022
+      "imdb_id": "tt1568338",
+      "votes": 155207,
+      "rating": 6.6,
+      "name": "Man on a Ledge",
+      "tvdb_id": 49527
     },
     {
-      "imdb_id": "nm0003482",
       "type": "Actor",
-      "name": "Nash Edgerton",
-      "tvdb_id": 75131
+      "imdb_id": "nm1107001",
+      "tvdb_id": 53650,
+      "name": "Anthony Mackie"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0133093",
-      "votes": 1950577,
-      "rating": 8.7,
-      "name": "The Matrix",
-      "tvdb_id": 603
+      "imdb_id": "tt0405159",
+      "votes": 698263,
+      "rating": 8.1,
+      "name": "Million Dollar Baby",
+      "tvdb_id": 70
     },
     {
-      "imdb_id": "nm0005251",
       "type": "Actor",
-      "name": "Carrie-Anne Moss",
-      "tvdb_id": 530
+      "imdb_id": "nm0000142",
+      "tvdb_id": 190,
+      "name": "Clint Eastwood"
     }
   ]
 }

--- a/puzzles/2023-08-03.json
+++ b/puzzles/2023-08-03.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 4491,
-  "target_tvdb_id": 3036,
-  "source_imdb_id": "nm0000098",
-  "target_imdb_id": "nm0000131",
+  "source_tvdb_id": 93210,
+  "target_tvdb_id": 37917,
+  "source_imdb_id": "nm1727304",
+  "target_imdb_id": "nm0829576",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000098",
       "type": "Actor",
-      "name": "Jennifer Aniston",
-      "tvdb_id": 4491
+      "imdb_id": "nm1727304",
+      "tvdb_id": 93210,
+      "name": "Domhnall Gleeson"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0151804",
-      "votes": 274610,
-      "rating": 7.6,
-      "name": "Office Space",
-      "tvdb_id": 1542
+      "imdb_id": "tt1201607",
+      "votes": 897033,
+      "rating": 8.1,
+      "name": "Harry Potter and the Deathly Hallows: Part 2",
+      "tvdb_id": 12445
     },
     {
-      "imdb_id": "nm0001525",
       "type": "Actor",
-      "name": "John C. McGinley",
-      "tvdb_id": 11885
+      "imdb_id": "nm0499270",
+      "tvdb_id": 60348,
+      "name": "Dave Legeno"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0309698",
-      "votes": 255572,
-      "rating": 7.3,
-      "name": "Identity",
-      "tvdb_id": 2832
+      "imdb_id": "tt1735898",
+      "votes": 294509,
+      "rating": 6.1,
+      "name": "Snow White and the Huntsman",
+      "tvdb_id": 58595
     },
     {
-      "imdb_id": "nm0000131",
       "type": "Actor",
-      "name": "John Cusack",
-      "tvdb_id": 3036
+      "imdb_id": "nm0829576",
+      "tvdb_id": 37917,
+      "name": "Kristen Stewart"
     }
   ]
 }

--- a/puzzles/2023-08-04.json
+++ b/puzzles/2023-08-04.json
@@ -1,15 +1,30 @@
 {
-  "source_tvdb_id": 7060,
-  "target_tvdb_id": 12073,
-  "source_imdb_id": "nm0293509",
-  "target_imdb_id": "nm0000196",
+  "source_tvdb_id": 3392,
+  "target_tvdb_id": 1245,
+  "source_imdb_id": "nm0000140",
+  "target_imdb_id": "nm0424060",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0293509",
       "type": "Actor",
-      "name": "Martin Freeman",
-      "tvdb_id": 7060
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0478970",
+      "votes": 689185,
+      "rating": 7.3,
+      "name": "Ant-Man",
+      "tvdb_id": 102899
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
     },
     {
       "type": "Film",
@@ -20,24 +35,10 @@
       "tvdb_id": 271110
     },
     {
-      "imdb_id": "nm0117709",
       "type": "Actor",
-      "name": "Daniel Br\u00fchl",
-      "tvdb_id": 3872
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt0361748",
-      "votes": 1485428,
-      "rating": 8.3,
-      "name": "Inglourious Basterds",
-      "tvdb_id": 16869
-    },
-    {
-      "imdb_id": "nm0000196",
-      "type": "Actor",
-      "name": "Mike Myers",
-      "tvdb_id": 12073
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
     }
   ]
 }

--- a/puzzles/2023-08-05.json
+++ b/puzzles/2023-08-05.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 118,
-  "target_tvdb_id": 1204,
-  "source_imdb_id": "nm0001691",
-  "target_imdb_id": "nm0000210",
+  "source_tvdb_id": 3490,
+  "target_tvdb_id": 1892,
+  "source_imdb_id": "nm0004778",
+  "target_imdb_id": "nm0000354",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0001691",
       "type": "Actor",
-      "name": "Geoffrey Rush",
-      "tvdb_id": 118
+      "imdb_id": "nm0004778",
+      "tvdb_id": 3490,
+      "name": "Adrien Brody"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0138524",
-      "votes": 99541,
-      "rating": 6.3,
-      "name": "Intolerable Cruelty",
-      "tvdb_id": 11775
+      "imdb_id": "tt1424381",
+      "votes": 236313,
+      "rating": 6.4,
+      "name": "Predators",
+      "tvdb_id": 34851
     },
     {
-      "imdb_id": "nm0000123",
       "type": "Actor",
-      "name": "George Clooney",
-      "tvdb_id": 1461
+      "imdb_id": "nm0103797",
+      "tvdb_id": 8602,
+      "name": "Alice Braga"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0349903",
-      "votes": 399386,
-      "rating": 6.5,
-      "name": "Ocean's Twelve",
-      "tvdb_id": 163
+      "imdb_id": "tt1535108",
+      "votes": 456360,
+      "rating": 6.6,
+      "name": "Elysium",
+      "tvdb_id": 68724
     },
     {
-      "imdb_id": "nm0000210",
       "type": "Actor",
-      "name": "Julia Roberts",
-      "tvdb_id": 1204
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
     }
   ]
 }

--- a/puzzles/2023-08-06.json
+++ b/puzzles/2023-08-06.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 173431,
-  "target_tvdb_id": 139,
-  "source_imdb_id": "nm0021600",
-  "target_imdb_id": "nm0000235",
+  "source_tvdb_id": 21657,
+  "target_tvdb_id": 27428,
+  "source_imdb_id": "nm0267812",
+  "target_imdb_id": "nm1093951",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0021600",
       "type": "Actor",
-      "name": "Bruce Allpress",
-      "tvdb_id": 173431
+      "imdb_id": "nm0267812",
+      "tvdb_id": 21657,
+      "name": "Vera Farmiga"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0167261",
-      "votes": 1697780,
-      "rating": 8.8,
-      "name": "The Lord of the Rings: The Two Towers",
-      "tvdb_id": 121
+      "imdb_id": "tt1872194",
+      "votes": 195758,
+      "rating": 7.4,
+      "name": "The Judge",
+      "tvdb_id": 205587
     },
     {
-      "imdb_id": "nm0000293",
       "type": "Actor",
-      "name": "Sean Bean",
-      "tvdb_id": 48
+      "imdb_id": "nm0000375",
+      "tvdb_id": 3223,
+      "name": "Robert Downey Jr."
     },
     {
       "type": "Film",
-      "imdb_id": "tt0814255",
-      "votes": 193436,
-      "rating": 5.8,
-      "name": "Percy Jackson & the Olympians: The Lightning Thief",
-      "tvdb_id": 32657
+      "imdb_id": "tt2395427",
+      "votes": 881783,
+      "rating": 7.3,
+      "name": "Avengers: Age of Ultron",
+      "tvdb_id": 99861
     },
     {
-      "imdb_id": "nm0000235",
       "type": "Actor",
-      "name": "Uma Thurman",
-      "tvdb_id": 139
+      "imdb_id": "nm1093951",
+      "tvdb_id": 27428,
+      "name": "Aaron Taylor-Johnson"
     }
   ]
 }

--- a/puzzles/2023-08-07.json
+++ b/puzzles/2023-08-07.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 7399,
-  "target_tvdb_id": 5472,
-  "source_imdb_id": "nm0001774",
-  "target_imdb_id": "nm0000147",
+  "source_tvdb_id": 6885,
+  "target_tvdb_id": 103,
+  "source_imdb_id": "nm0000234",
+  "target_imdb_id": "nm0749263",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0001774",
       "type": "Actor",
-      "name": "Ben Stiller",
-      "tvdb_id": 7399
+      "imdb_id": "nm0000234",
+      "tvdb_id": 6885,
+      "name": "Charlize Theron"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0115798",
-      "votes": 170281,
+      "imdb_id": "tt1735898",
+      "votes": 294509,
       "rating": 6.1,
-      "name": "The Cable Guy",
-      "tvdb_id": 9894
+      "name": "Snow White and the Huntsman",
+      "tvdb_id": 58595
     },
     {
-      "imdb_id": "nm0000120",
       "type": "Actor",
-      "name": "Jim Carrey",
-      "tvdb_id": 206
+      "imdb_id": "nm1165110",
+      "tvdb_id": 74568,
+      "name": "Chris Hemsworth"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1067106",
-      "votes": 122010,
-      "rating": 6.8,
-      "name": "A Christmas Carol",
-      "tvdb_id": 17979
+      "imdb_id": "tt0848228",
+      "votes": 1411541,
+      "rating": 8.0,
+      "name": "The Avengers",
+      "tvdb_id": 24428
     },
     {
-      "imdb_id": "nm0000147",
       "type": "Actor",
-      "name": "Colin Firth",
-      "tvdb_id": 5472
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
     }
   ]
 }

--- a/puzzles/2023-08-08.json
+++ b/puzzles/2023-08-08.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 976,
-  "target_tvdb_id": 27578,
-  "source_imdb_id": "nm0005458",
-  "target_imdb_id": "nm0680983",
+  "source_tvdb_id": 4483,
+  "target_tvdb_id": 17288,
+  "source_imdb_id": "nm0000163",
+  "target_imdb_id": "nm1055413",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0005458",
       "type": "Actor",
-      "name": "Jason Statham",
-      "tvdb_id": 976
+      "imdb_id": "nm0000163",
+      "tvdb_id": 4483,
+      "name": "Dustin Hoffman"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0120735",
-      "votes": 593453,
-      "rating": 8.1,
-      "name": "Lock, Stock and Two Smoking Barrels",
-      "tvdb_id": 100
+      "imdb_id": "tt0117665",
+      "votes": 229687,
+      "rating": 7.5,
+      "name": "Sleepers",
+      "tvdb_id": 819
     },
     {
-      "imdb_id": "nm4798882",
       "type": "Actor",
-      "name": "Brad Jacobowitz",
-      "tvdb_id": null
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1375666",
-      "votes": 2403153,
-      "rating": 8.8,
-      "name": "Inception",
-      "tvdb_id": 27205
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
     },
     {
-      "imdb_id": "nm0680983",
       "type": "Actor",
-      "name": "Elliot Page",
-      "tvdb_id": 27578
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
     }
   ]
 }

--- a/puzzles/2023-08-09.json
+++ b/puzzles/2023-08-09.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 976,
-  "target_tvdb_id": 776,
-  "source_imdb_id": "nm0005458",
-  "target_imdb_id": "nm0000552",
+  "source_tvdb_id": 6941,
+  "target_tvdb_id": 2232,
+  "source_imdb_id": "nm0000139",
+  "target_imdb_id": "nm0000474",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0005458",
       "type": "Actor",
-      "name": "Jason Statham",
-      "tvdb_id": 976
+      "imdb_id": "nm0000139",
+      "tvdb_id": 6941,
+      "name": "Cameron Diaz"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0452608",
-      "votes": 213082,
-      "rating": 6.4,
-      "name": "Death Race",
-      "tvdb_id": 10483
-    },
-    {
-      "imdb_id": "nm0574534",
-      "type": "Actor",
-      "name": "Ian McShane",
-      "tvdb_id": 6972
-    },
-    {
-      "type": "Film",
-      "imdb_id": "tt0413267",
-      "votes": 317481,
+      "imdb_id": "tt1033643",
+      "votes": 180615,
       "rating": 6.1,
-      "name": "Shrek the Third",
-      "tvdb_id": 810
+      "name": "What Happens in Vegas",
+      "tvdb_id": 9029
     },
     {
-      "imdb_id": "nm0000552",
       "type": "Actor",
-      "name": "Eddie Murphy",
-      "tvdb_id": 776
+      "imdb_id": "nm0302108",
+      "tvdb_id": 58225,
+      "name": "Zach Galifianakis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2562232",
+      "votes": 643891,
+      "rating": 7.7,
+      "name": "Birdman or (The Unexpected Virtue of Ignorance)",
+      "tvdb_id": 194662
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000474",
+      "tvdb_id": 2232,
+      "name": "Michael Keaton"
     }
   ]
 }

--- a/puzzles/2023-08-10.json
+++ b/puzzles/2023-08-10.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 1204,
-  "target_tvdb_id": 1231,
-  "source_imdb_id": "nm0000210",
-  "target_imdb_id": "nm0000194",
+  "source_tvdb_id": 3131,
+  "target_tvdb_id": 6383,
+  "source_imdb_id": "nm0000104",
+  "target_imdb_id": "nm0001173",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0000210",
       "type": "Actor",
-      "name": "Julia Roberts",
-      "tvdb_id": 1204
+      "imdb_id": "nm0000104",
+      "tvdb_id": 3131,
+      "name": "Antonio Banderas"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0472062",
-      "votes": 121255,
-      "rating": 7.0,
-      "name": "Charlie Wilson's War",
-      "tvdb_id": 6538
+      "imdb_id": "tt0107818",
+      "votes": 247993,
+      "rating": 7.7,
+      "name": "Philadelphia",
+      "tvdb_id": 9800
     },
     {
-      "imdb_id": "nm0000450",
       "type": "Actor",
-      "name": "Philip Seymour Hoffman",
-      "tvdb_id": 1233
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0118715",
-      "votes": 824543,
-      "rating": 8.1,
-      "name": "The Big Lebowski",
-      "tvdb_id": 115
+      "imdb_id": "tt3263904",
+      "votes": 281723,
+      "rating": 7.4,
+      "name": "Sully",
+      "tvdb_id": 363676
     },
     {
-      "imdb_id": "nm0000194",
       "type": "Actor",
-      "name": "Julianne Moore",
-      "tvdb_id": 1231
+      "imdb_id": "nm0001173",
+      "tvdb_id": 6383,
+      "name": "Aaron Eckhart"
     }
   ]
 }

--- a/puzzles/2023-08-11.json
+++ b/puzzles/2023-08-11.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 37917,
-  "target_tvdb_id": 1100,
-  "source_imdb_id": "nm0829576",
-  "target_imdb_id": "nm0000216",
+  "source_tvdb_id": 74568,
+  "target_tvdb_id": 5064,
+  "source_imdb_id": "nm1165110",
+  "target_imdb_id": "nm0000658",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0829576",
       "type": "Actor",
-      "name": "Kristen Stewart",
-      "tvdb_id": 37917
+      "imdb_id": "nm1165110",
+      "tvdb_id": 74568,
+      "name": "Chris Hemsworth"
     },
     {
       "type": "Film",
-      "imdb_id": "tt1099212",
-      "votes": 470393,
-      "rating": 5.3,
-      "name": "Twilight",
-      "tvdb_id": 8966
+      "imdb_id": "tt3501632",
+      "votes": 771855,
+      "rating": 7.9,
+      "name": "Thor: Ragnarok",
+      "tvdb_id": 284053
     },
     {
-      "imdb_id": "nm1553725",
       "type": "Actor",
-      "name": "Kellan Lutz",
-      "tvdb_id": 34502
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2333784",
-      "votes": 187193,
-      "rating": 6.1,
-      "name": "The Expendables 3",
-      "tvdb_id": 138103
+      "imdb_id": "tt11286314",
+      "votes": 555062,
+      "rating": 7.2,
+      "name": "Don't Look Up",
+      "tvdb_id": 646380
     },
     {
-      "imdb_id": "nm0000216",
       "type": "Actor",
-      "name": "Arnold Schwarzenegger",
-      "tvdb_id": 1100
+      "imdb_id": "nm0000658",
+      "tvdb_id": 5064,
+      "name": "Meryl Streep"
     }
   ]
 }

--- a/puzzles/2023-08-12.json
+++ b/puzzles/2023-08-12.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2157,
-  "target_tvdb_id": 8691,
-  "source_imdb_id": "nm0000245",
-  "target_imdb_id": "nm0757855",
+  "source_tvdb_id": 976,
+  "target_tvdb_id": 139,
+  "source_imdb_id": "nm0005458",
+  "target_imdb_id": "nm0000235",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0000245",
       "type": "Actor",
-      "name": "Robin Williams",
-      "tvdb_id": 2157
+      "imdb_id": "nm0005458",
+      "tvdb_id": 976,
+      "name": "Jason Statham"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0102057",
-      "votes": 262088,
-      "rating": 6.8,
-      "name": "Hook",
-      "tvdb_id": 879
+      "imdb_id": "tt0452608",
+      "votes": 213082,
+      "rating": 6.4,
+      "name": "Death Race",
+      "tvdb_id": 10483
     },
     {
-      "imdb_id": "nm0000335",
       "type": "Actor",
-      "name": "Glenn Close",
-      "tvdb_id": 515
+      "imdb_id": "nm0001016",
+      "tvdb_id": 141,
+      "name": "David Carradine"
     },
     {
       "type": "Film",
-      "imdb_id": "tt2015381",
-      "votes": 1202667,
-      "rating": 8.0,
-      "name": "Guardians of the Galaxy",
-      "tvdb_id": 118340
+      "imdb_id": "tt0266697",
+      "votes": 1136931,
+      "rating": 8.2,
+      "name": "Kill Bill: Vol. 1",
+      "tvdb_id": 24
     },
     {
-      "imdb_id": "nm0757855",
       "type": "Actor",
-      "name": "Zoe Saldana",
-      "tvdb_id": 8691
+      "imdb_id": "nm0000235",
+      "tvdb_id": 139,
+      "name": "Uma Thurman"
     }
   ]
 }

--- a/puzzles/2023-08-13.json
+++ b/puzzles/2023-08-13.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 65731,
-  "target_tvdb_id": 5081,
-  "source_imdb_id": "nm0941777",
-  "target_imdb_id": "nm1289434",
+  "source_tvdb_id": 112,
+  "target_tvdb_id": 18277,
+  "source_imdb_id": "nm0000949",
+  "target_imdb_id": "nm0000113",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0941777",
       "type": "Actor",
-      "name": "Sam Worthington",
-      "tvdb_id": 65731
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0800320",
-      "votes": 286593,
-      "rating": 5.8,
-      "name": "Clash of the Titans",
-      "tvdb_id": 18823
+      "imdb_id": "tt0421715",
+      "votes": 665678,
+      "rating": 7.8,
+      "name": "The Curious Case of Benjamin Button",
+      "tvdb_id": 4922
     },
     {
-      "imdb_id": "nm1812656",
       "type": "Actor",
-      "name": "Luke Evans",
-      "tvdb_id": 114019
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3631112",
-      "votes": 192096,
-      "rating": 6.5,
-      "name": "The Girl on the Train",
-      "tvdb_id": 346685
+      "imdb_id": "tt12593682",
+      "votes": 348287,
+      "rating": 7.3,
+      "name": "Bullet Train",
+      "tvdb_id": 718930
     },
     {
-      "imdb_id": "nm1289434",
       "type": "Actor",
-      "name": "Emily Blunt",
-      "tvdb_id": 5081
+      "imdb_id": "nm0000113",
+      "tvdb_id": 18277,
+      "name": "Sandra Bullock"
     }
   ]
 }

--- a/puzzles/2023-08-14.json
+++ b/puzzles/2023-08-14.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 290,
-  "target_tvdb_id": 5530,
-  "source_imdb_id": "nm0001626",
-  "target_imdb_id": "nm0564215",
+  "source_tvdb_id": 17604,
+  "target_tvdb_id": 2975,
+  "source_imdb_id": "nm0719637",
+  "target_imdb_id": "nm0000401",
   "min_moves_to_solve": 3,
+  "source_birthday": false,
   "best_solution": [
     {
-      "imdb_id": "nm0001626",
       "type": "Actor",
-      "name": "Christopher Plummer",
-      "tvdb_id": 290
+      "imdb_id": "nm0719637",
+      "tvdb_id": 17604,
+      "name": "Jeremy Renner"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0346491",
-      "votes": 172614,
-      "rating": 5.6,
-      "name": "Alexander",
-      "tvdb_id": 1966
+      "imdb_id": "tt2543164",
+      "votes": 715446,
+      "rating": 7.9,
+      "name": "Arrival",
+      "tvdb_id": 329865
     },
     {
-      "imdb_id": "nm0001401",
       "type": "Actor",
-      "name": "Angelina Jolie",
-      "tvdb_id": 11701
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0493464",
-      "votes": 396817,
-      "rating": 6.7,
-      "name": "Wanted",
-      "tvdb_id": 8909
+      "imdb_id": "tt2975590",
+      "votes": 710461,
+      "rating": 6.4,
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
     },
     {
-      "imdb_id": "nm0564215",
       "type": "Actor",
-      "name": "James McAvoy",
-      "tvdb_id": 5530
+      "imdb_id": "nm0000401",
+      "tvdb_id": 2975,
+      "name": "Laurence Fishburne"
     }
   ]
 }

--- a/puzzles/2023-08-15.json
+++ b/puzzles/2023-08-15.json
@@ -1,43 +1,44 @@
 {
-  "source_tvdb_id": 2282,
-  "target_tvdb_id": 3131,
-  "source_imdb_id": "nm0001426",
-  "target_imdb_id": "nm0000104",
+  "source_tvdb_id": 880,
+  "target_tvdb_id": 4937,
+  "source_imdb_id": "nm0000255",
+  "target_imdb_id": "nm0000681",
   "min_moves_to_solve": 3,
+  "source_birthday": true,
   "best_solution": [
     {
-      "imdb_id": "nm0001426",
       "type": "Actor",
-      "name": "Ben Kingsley",
-      "tvdb_id": 2282
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
     },
     {
       "type": "Film",
-      "imdb_id": "tt0970179",
-      "votes": 328128,
-      "rating": 7.5,
-      "name": "Hugo",
-      "tvdb_id": 44826
+      "imdb_id": "tt2267998",
+      "votes": 1004941,
+      "rating": 8.1,
+      "name": "Gone Girl",
+      "tvdb_id": 210577
     },
     {
-      "imdb_id": "nm0935653",
       "type": "Actor",
-      "name": "Ray Winstone",
-      "tvdb_id": 5538
+      "imdb_id": "nm0701512",
+      "tvdb_id": 1294,
+      "name": "Missi Pyle"
     },
     {
       "type": "Film",
-      "imdb_id": "tt3915174",
-      "votes": 123334,
-      "rating": 7.9,
-      "name": "Puss in Boots: The Last Wish",
-      "tvdb_id": 315162
+      "imdb_id": "tt0364725",
+      "votes": 256857,
+      "rating": 6.7,
+      "name": "Dodgeball: A True Underdog Story",
+      "tvdb_id": 9472
     },
     {
-      "imdb_id": "nm0000104",
       "type": "Actor",
-      "name": "Antonio Banderas",
-      "tvdb_id": 3131
+      "imdb_id": "nm0000681",
+      "tvdb_id": 4937,
+      "name": "Vince Vaughn"
     }
   ]
 }

--- a/puzzles/2023-08-16.json
+++ b/puzzles/2023-08-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4495,
+  "target_tvdb_id": 12898,
+  "source_imdb_id": "nm0136797",
+  "target_imdb_id": "nm0000741",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0136797",
+      "tvdb_id": 4495,
+      "name": "Steve Carell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1690953",
+      "votes": 409188,
+      "rating": 7.3,
+      "name": "Despicable Me 2",
+      "tvdb_id": 93456
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0029460",
+      "tvdb_id": 19545,
+      "name": "Jack Angel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114709",
+      "votes": 1014131,
+      "rating": 8.3,
+      "name": "Toy Story",
+      "tvdb_id": 862
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000741",
+      "tvdb_id": 12898,
+      "name": "Tim Allen"
+    }
+  ]
+}

--- a/puzzles/2023-08-17.json
+++ b/puzzles/2023-08-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 380,
+  "target_tvdb_id": 31,
+  "source_imdb_id": "nm0000134",
+  "target_imdb_id": "nm0000158",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0113277",
+      "votes": 670703,
+      "rating": 8.3,
+      "name": "Heat",
+      "tvdb_id": 949
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001744",
+      "tvdb_id": 3197,
+      "name": "Tom Sizemore"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120815",
+      "votes": 1418419,
+      "rating": 8.6,
+      "name": "Saving Private Ryan",
+      "tvdb_id": 857
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
+    }
+  ]
+}

--- a/puzzles/2023-08-18.json
+++ b/puzzles/2023-08-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 819,
+  "target_tvdb_id": 62064,
+  "source_imdb_id": "nm0001570",
+  "target_imdb_id": "nm1517976",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001570",
+      "tvdb_id": 819,
+      "name": "Edward Norton"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120586",
+      "votes": 1140151,
+      "rating": 8.5,
+      "name": "American History X",
+      "tvdb_id": 73
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0839486",
+      "tvdb_id": 824,
+      "name": "Ethan Suplee"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0477080",
+      "votes": 201551,
+      "rating": 6.8,
+      "name": "Unstoppable",
+      "tvdb_id": 44048
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1517976",
+      "tvdb_id": 62064,
+      "name": "Chris Pine"
+    }
+  ]
+}

--- a/puzzles/2023-08-19.json
+++ b/puzzles/2023-08-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 9273,
+  "target_tvdb_id": 854,
+  "source_imdb_id": "nm0010736",
+  "target_imdb_id": "nm0000071",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0862846",
+      "votes": 72617,
+      "rating": 6.8,
+      "name": "Sunshine Cleaning",
+      "tvdb_id": 13090
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004286",
+      "tvdb_id": 5365,
+      "name": "Clifton Collins Jr."
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0107554",
+      "votes": 61419,
+      "rating": 7.5,
+      "name": "Menace II Society",
+      "tvdb_id": 9516
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000071",
+      "tvdb_id": 854,
+      "name": "James Stewart"
+    }
+  ]
+}

--- a/puzzles/2023-08-20.json
+++ b/puzzles/2023-08-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 9273,
+  "target_tvdb_id": 1037,
+  "source_imdb_id": "nm0010736",
+  "target_imdb_id": "nm0000172",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0264464",
+      "votes": 1015683,
+      "rating": 8.1,
+      "name": "Catch Me If You Can",
+      "tvdb_id": 640
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0751902",
+      "tvdb_id": 99087,
+      "name": "Robert Ruth"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0105236",
+      "votes": 1039363,
+      "rating": 8.3,
+      "name": "Reservoir Dogs",
+      "tvdb_id": 500
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000172",
+      "tvdb_id": 1037,
+      "name": "Harvey Keitel"
+    }
+  ]
+}

--- a/puzzles/2023-08-21.json
+++ b/puzzles/2023-08-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 530,
+  "target_tvdb_id": 21657,
+  "source_imdb_id": "nm0005251",
+  "target_imdb_id": "nm0267812",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005251",
+      "tvdb_id": 530,
+      "name": "Carrie-Anne Moss"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0133093",
+      "votes": 1950577,
+      "rating": 8.7,
+      "name": "The Matrix",
+      "tvdb_id": 603
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm3269395",
+      "tvdb_id": 1209257,
+      "name": "Rana Morrison"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0945513",
+      "votes": 529835,
+      "rating": 7.5,
+      "name": "Source Code",
+      "tvdb_id": 45612
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0267812",
+      "tvdb_id": 21657,
+      "name": "Vera Farmiga"
+    }
+  ]
+}

--- a/puzzles/2023-08-22.json
+++ b/puzzles/2023-08-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 41091,
+  "target_tvdb_id": 976,
+  "source_imdb_id": "nm1325419",
+  "target_imdb_id": "nm0005458",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1325419",
+      "tvdb_id": 41091,
+      "name": "Kristen Wiig"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1478338",
+      "votes": 298378,
+      "rating": 6.8,
+      "name": "Bridesmaids",
+      "tvdb_id": 55721
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0187719",
+      "tvdb_id": 53256,
+      "name": "Terry Crews"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1764651",
+      "votes": 312651,
+      "rating": 6.6,
+      "name": "The Expendables 2",
+      "tvdb_id": 76163
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005458",
+      "tvdb_id": 976,
+      "name": "Jason Statham"
+    }
+  ]
+}

--- a/puzzles/2023-08-23.json
+++ b/puzzles/2023-08-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2228,
+  "target_tvdb_id": 1038,
+  "source_imdb_id": "nm0000576",
+  "target_imdb_id": "nm0000149",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000576",
+      "tvdb_id": 2228,
+      "name": "Sean Penn"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1013753",
+      "votes": 175964,
+      "rating": 7.5,
+      "name": "Milk",
+      "tvdb_id": 10139
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0526019",
+      "tvdb_id": 8688,
+      "name": "Diego Luna"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1535108",
+      "votes": 456360,
+      "rating": 6.6,
+      "name": "Elysium",
+      "tvdb_id": 68724
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000149",
+      "tvdb_id": 1038,
+      "name": "Jodie Foster"
+    }
+  ]
+}

--- a/puzzles/2023-08-24.json
+++ b/puzzles/2023-08-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1230,
+  "target_tvdb_id": 6730,
+  "source_imdb_id": "nm0000422",
+  "target_imdb_id": "nm0056187",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000422",
+      "tvdb_id": 1230,
+      "name": "John Goodman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1655442",
+      "votes": 244505,
+      "rating": 7.9,
+      "name": "The Artist",
+      "tvdb_id": 74643
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0205772",
+      "tvdb_id": 6734,
+      "name": "Ken Davitian"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0443453",
+      "votes": 421379,
+      "rating": 7.4,
+      "name": "Borat",
+      "tvdb_id": 496
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0056187",
+      "tvdb_id": 6730,
+      "name": "Sacha Baron Cohen"
+    }
+  ]
+}

--- a/puzzles/2023-08-25.json
+++ b/puzzles/2023-08-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 738,
+  "target_tvdb_id": 2283,
+  "source_imdb_id": "nm0000125",
+  "target_imdb_id": "nm0001804",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000125",
+      "tvdb_id": 738,
+      "name": "Sean Connery"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0137494",
+      "votes": 119829,
+      "rating": 6.3,
+      "name": "Entrapment",
+      "tvdb_id": 1844
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001876",
+      "tvdb_id": 1922,
+      "name": "Catherine Zeta-Jones"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0362227",
+      "votes": 471100,
+      "rating": 7.4,
+      "name": "The Terminal",
+      "tvdb_id": 594
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001804",
+      "tvdb_id": 2283,
+      "name": "Stanley Tucci"
+    }
+  ]
+}

--- a/puzzles/2023-08-26.json
+++ b/puzzles/2023-08-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 62064,
+  "target_tvdb_id": 2219,
+  "source_imdb_id": "nm1517976",
+  "target_imdb_id": "nm0001497",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1517976",
+      "tvdb_id": 62064,
+      "name": "Chris Pine"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1408101",
+      "votes": 488621,
+      "rating": 7.7,
+      "name": "Star Trek Into Darkness",
+      "tvdb_id": 54138
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1212722",
+      "tvdb_id": 71580,
+      "name": "Benedict Cumberbatch"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt10872600",
+      "votes": 789409,
+      "rating": 8.2,
+      "name": "Spider-Man: No Way Home",
+      "tvdb_id": 634649
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001497",
+      "tvdb_id": 2219,
+      "name": "Tobey Maguire"
+    }
+  ]
+}

--- a/puzzles/2023-08-27.json
+++ b/puzzles/2023-08-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 65731,
+  "target_tvdb_id": 21007,
+  "source_imdb_id": "nm0941777",
+  "target_imdb_id": "nm1706767",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1568338",
+      "votes": 155207,
+      "rating": 6.6,
+      "name": "Man on a Ledge",
+      "tvdb_id": 49527
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0167024",
+      "tvdb_id": 2256,
+      "name": "Robert Clohessy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0993846",
+      "votes": 1455112,
+      "rating": 8.2,
+      "name": "The Wolf of Wall Street",
+      "tvdb_id": 106646
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    }
+  ]
+}

--- a/puzzles/2023-08-28.json
+++ b/puzzles/2023-08-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 70851,
+  "target_tvdb_id": 2975,
+  "source_imdb_id": "nm0085312",
+  "target_imdb_id": "nm0000401",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0085312",
+      "tvdb_id": 70851,
+      "name": "Jack Black"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0360717",
+      "votes": 432227,
+      "rating": 7.2,
+      "name": "King Kong",
+      "tvdb_id": 254
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004778",
+      "tvdb_id": 3490,
+      "name": "Adrien Brody"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1424381",
+      "votes": 236313,
+      "rating": 6.4,
+      "name": "Predators",
+      "tvdb_id": 34851
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000401",
+      "tvdb_id": 2975,
+      "name": "Laurence Fishburne"
+    }
+  ]
+}

--- a/puzzles/2023-08-29.json
+++ b/puzzles/2023-08-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6856,
+  "target_tvdb_id": 3894,
+  "source_imdb_id": "nm0000621",
+  "target_imdb_id": "nm0000288",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000621",
+      "tvdb_id": 6856,
+      "name": "Kurt Russell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3460252",
+      "votes": 620842,
+      "rating": 7.8,
+      "name": "The Hateful Eight",
+      "tvdb_id": 273248
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000492",
+      "tvdb_id": 10431,
+      "name": "Jennifer Jason Leigh"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361862",
+      "votes": 399714,
+      "rating": 7.7,
+      "name": "The Machinist",
+      "tvdb_id": 4553
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    }
+  ]
+}

--- a/puzzles/2023-08-30.json
+++ b/puzzles/2023-08-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6941,
+  "target_tvdb_id": 1327,
+  "source_imdb_id": "nm0000139",
+  "target_imdb_id": "nm0005212",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000139",
+      "tvdb_id": 6941,
+      "name": "Cameron Diaz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0457939",
+      "votes": 300223,
+      "rating": 6.9,
+      "name": "The Holiday",
+      "tvdb_id": 1581
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0424095",
+      "votes": 131559,
+      "rating": 6.6,
+      "name": "Flushed Away",
+      "tvdb_id": 11619
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005212",
+      "tvdb_id": 1327,
+      "name": "Ian McKellen"
+    }
+  ]
+}

--- a/puzzles/2023-08-31.json
+++ b/puzzles/2023-08-31.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 134,
+  "target_tvdb_id": 9642,
+  "source_imdb_id": "nm0004937",
+  "target_imdb_id": "nm0000179",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338751",
+      "votes": 370181,
+      "rating": 7.5,
+      "name": "The Aviator",
+      "tvdb_id": 2567
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000179",
+      "tvdb_id": 9642,
+      "name": "Jude Law"
+    }
+  ]
+}

--- a/puzzles/2023-09-01.json
+++ b/puzzles/2023-09-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 37625,
+  "target_tvdb_id": 6941,
+  "source_imdb_id": "nm1940449",
+  "target_imdb_id": "nm0000139",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1940449",
+      "tvdb_id": 37625,
+      "name": "Andrew Garfield"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1872181",
+      "votes": 510599,
+      "rating": 6.6,
+      "name": "The Amazing Spider-Man 2",
+      "tvdb_id": 102382
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0146838",
+      "votes": 122619,
+      "rating": 6.9,
+      "name": "Any Given Sunday",
+      "tvdb_id": 9563
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000139",
+      "tvdb_id": 6941,
+      "name": "Cameron Diaz"
+    }
+  ]
+}

--- a/puzzles/2023-09-02.json
+++ b/puzzles/2023-09-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6384,
+  "target_tvdb_id": 206,
+  "source_imdb_id": "nm0000206",
+  "target_imdb_id": "nm0000120",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000206",
+      "tvdb_id": 6384,
+      "name": "Keanu Reeves"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0111257",
+      "votes": 374742,
+      "rating": 7.3,
+      "name": "Speed",
+      "tvdb_id": 1637
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001099",
+      "tvdb_id": 8447,
+      "name": "Jeff Daniels"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0109686",
+      "votes": 394818,
+      "rating": 7.3,
+      "name": "Dumb and Dumber",
+      "tvdb_id": 8467
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000120",
+      "tvdb_id": 206,
+      "name": "Jim Carrey"
+    }
+  ]
+}

--- a/puzzles/2023-09-03.json
+++ b/puzzles/2023-09-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 173431,
+  "target_tvdb_id": 6384,
+  "source_imdb_id": "nm0021600",
+  "target_imdb_id": "nm0000206",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0021600",
+      "tvdb_id": 173431,
+      "name": "Bruce Allpress"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0167261",
+      "votes": 1697780,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Two Towers",
+      "tvdb_id": 121
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915989",
+      "tvdb_id": 1331,
+      "name": "Hugo Weaving"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0133093",
+      "votes": 1950577,
+      "rating": 8.7,
+      "name": "The Matrix",
+      "tvdb_id": 603
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000206",
+      "tvdb_id": 6384,
+      "name": "Keanu Reeves"
+    }
+  ]
+}

--- a/puzzles/2023-09-04.json
+++ b/puzzles/2023-09-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 12052,
+  "target_tvdb_id": 9560,
+  "source_imdb_id": "nm0000569",
+  "target_imdb_id": "nm0000995",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000569",
+      "tvdb_id": 12052,
+      "name": "Gwyneth Paltrow"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0134119",
+      "votes": 218069,
+      "rating": 7.4,
+      "name": "The Talented Mr. Ripley",
+      "tvdb_id": 1213
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
+    }
+  ]
+}

--- a/puzzles/2023-09-05.json
+++ b/puzzles/2023-09-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2232,
+  "target_tvdb_id": 4517,
+  "source_imdb_id": "nm0000474",
+  "target_imdb_id": "nm0000582",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000474",
+      "tvdb_id": 2232,
+      "name": "Michael Keaton"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119396",
+      "votes": 357708,
+      "rating": 7.5,
+      "name": "Jackie Brown",
+      "tvdb_id": 184
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0099685",
+      "votes": 1186782,
+      "rating": 8.7,
+      "name": "Goodfellas",
+      "tvdb_id": 769
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000582",
+      "tvdb_id": 4517,
+      "name": "Joe Pesci"
+    }
+  ]
+}

--- a/puzzles/2023-09-06.json
+++ b/puzzles/2023-09-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 8784,
+  "target_tvdb_id": 22226,
+  "source_imdb_id": "nm0185819",
+  "target_imdb_id": "nm0748620",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0185819",
+      "tvdb_id": 8784,
+      "name": "Daniel Craig"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt11564570",
+      "votes": 385583,
+      "rating": 7.1,
+      "name": "Glass Onion",
+      "tvdb_id": 661374
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1063517",
+      "tvdb_id": 17696,
+      "name": "Kathryn Hahn"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0357413",
+      "votes": 365542,
+      "rating": 7.1,
+      "name": "Anchorman: The Legend of Ron Burgundy",
+      "tvdb_id": 8699
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
+    }
+  ]
+}

--- a/puzzles/2023-09-07.json
+++ b/puzzles/2023-09-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4517,
+  "target_tvdb_id": 204,
+  "source_imdb_id": "nm0000582",
+  "target_imdb_id": "nm0000701",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000582",
+      "tvdb_id": 4517,
+      "name": "Joe Pesci"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1302006",
+      "votes": 401561,
+      "rating": 7.8,
+      "name": "The Irishman",
+      "tvdb_id": 398978
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1677477",
+      "tvdb_id": 164094,
+      "name": "Marin Ireland"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0959337",
+      "votes": 218090,
+      "rating": 7.3,
+      "name": "Revolutionary Road",
+      "tvdb_id": 4148
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
+    }
+  ]
+}

--- a/puzzles/2023-09-08.json
+++ b/puzzles/2023-09-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 7060,
+  "target_tvdb_id": 4756,
+  "source_imdb_id": "nm0293509",
+  "target_imdb_id": "nm0000111",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0293509",
+      "tvdb_id": 7060,
+      "name": "Martin Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0314331",
+      "votes": 502629,
+      "rating": 7.6,
+      "name": "Love Actually",
+      "tvdb_id": 508
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000100",
+      "tvdb_id": 10730,
+      "name": "Rowan Atkinson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110357",
+      "votes": 1080805,
+      "rating": 8.5,
+      "name": "The Lion King",
+      "tvdb_id": 8587
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000111",
+      "tvdb_id": 4756,
+      "name": "Matthew Broderick"
+    }
+  ]
+}

--- a/puzzles/2023-09-09.json
+++ b/puzzles/2023-09-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 19292,
+  "target_tvdb_id": 6384,
+  "source_imdb_id": "nm0001191",
+  "target_imdb_id": "nm0000206",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001191",
+      "tvdb_id": 19292,
+      "name": "Adam Sandler"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0810913",
+      "votes": 86909,
+      "rating": 3.3,
+      "name": "Jack and Jill",
+      "tvdb_id": 71880
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0118971",
+      "votes": 383056,
+      "rating": 7.5,
+      "name": "The Devil's Advocate",
+      "tvdb_id": 1813
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000206",
+      "tvdb_id": 6384,
+      "name": "Keanu Reeves"
+    }
+  ]
+}

--- a/puzzles/2023-09-10.json
+++ b/puzzles/2023-09-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5472,
+  "target_tvdb_id": 31,
+  "source_imdb_id": "nm0000147",
+  "target_imdb_id": "nm0000158",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000147",
+      "tvdb_id": 5472,
+      "name": "Colin Firth"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2802144",
+      "votes": 683363,
+      "rating": 7.7,
+      "name": "Kingsman: The Secret Service",
+      "tvdb_id": 207703
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0424819",
+      "tvdb_id": 17199,
+      "name": "Corey Johnson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120815",
+      "votes": 1418419,
+      "rating": 8.6,
+      "name": "Saving Private Ryan",
+      "tvdb_id": 857
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
+    }
+  ]
+}

--- a/puzzles/2023-09-11.json
+++ b/puzzles/2023-09-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 72129,
+  "target_tvdb_id": 204,
+  "source_imdb_id": "nm2225369",
+  "target_imdb_id": "nm0000701",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm2225369",
+      "tvdb_id": 72129,
+      "name": "Jennifer Lawrence"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt11286314",
+      "votes": 555062,
+      "rating": 7.2,
+      "name": "Don't Look Up",
+      "tvdb_id": 646380
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120338",
+      "votes": 1215558,
+      "rating": 7.9,
+      "name": "Titanic",
+      "tvdb_id": 597
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
+    }
+  ]
+}

--- a/puzzles/2023-09-12.json
+++ b/puzzles/2023-09-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 8167,
+  "target_tvdb_id": 2888,
+  "source_imdb_id": "nm0908094",
+  "target_imdb_id": "nm0000226",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0908094",
+      "tvdb_id": 8167,
+      "name": "Paul Walker"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0322259",
+      "votes": 280975,
+      "rating": 5.9,
+      "name": "2 Fast 2 Furious",
+      "tvdb_id": 584
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0578949",
+      "tvdb_id": 8170,
+      "name": "Eva Mendes"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0386588",
+      "votes": 324142,
+      "rating": 6.6,
+      "name": "Hitch",
+      "tvdb_id": 8488
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000226",
+      "tvdb_id": 2888,
+      "name": "Will Smith"
+    }
+  ]
+}

--- a/puzzles/2023-09-13.json
+++ b/puzzles/2023-09-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5081,
+  "target_tvdb_id": 819,
+  "source_imdb_id": "nm1289434",
+  "target_imdb_id": "nm0001570",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1289434",
+      "tvdb_id": 5081,
+      "name": "Emily Blunt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1276104",
+      "votes": 585768,
+      "rating": 7.4,
+      "name": "Looper",
+      "tvdb_id": 59967
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000246",
+      "tvdb_id": 62,
+      "name": "Bruce Willis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1748122",
+      "votes": 356088,
+      "rating": 7.8,
+      "name": "Moonrise Kingdom",
+      "tvdb_id": 83666
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001570",
+      "tvdb_id": 819,
+      "name": "Edward Norton"
+    }
+  ]
+}

--- a/puzzles/2023-09-14.json
+++ b/puzzles/2023-09-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4783,
+  "target_tvdb_id": 18269,
+  "source_imdb_id": "nm0000554",
+  "target_imdb_id": "nm0000409",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000554",
+      "tvdb_id": 4783,
+      "name": "Sam Neill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0099810",
+      "votes": 206218,
+      "rating": 7.5,
+      "name": "The Hunt for Red October",
+      "tvdb_id": 1669
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1433660",
+      "tvdb_id": 27678,
+      "name": "Tom Fisher"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0209163",
+      "votes": 334054,
+      "rating": 6.4,
+      "name": "The Mummy Returns",
+      "tvdb_id": 1734
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000409",
+      "tvdb_id": 18269,
+      "name": "Brendan Fraser"
+    }
+  ]
+}

--- a/puzzles/2023-09-15.json
+++ b/puzzles/2023-09-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2524,
+  "target_tvdb_id": 6161,
+  "source_imdb_id": "nm0362766",
+  "target_imdb_id": "nm0000124",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0362766",
+      "tvdb_id": 2524,
+      "name": "Tom Hardy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0450259",
+      "votes": 562068,
+      "rating": 8.0,
+      "name": "Blood Diamond",
+      "tvdb_id": 1372
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000124",
+      "tvdb_id": 6161,
+      "name": "Jennifer Connelly"
+    }
+  ]
+}

--- a/puzzles/2023-09-16.json
+++ b/puzzles/2023-09-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17288,
+  "target_tvdb_id": 7447,
+  "source_imdb_id": "nm1055413",
+  "target_imdb_id": "nm0000285",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1877832",
+      "votes": 723350,
+      "rating": 7.9,
+      "name": "X-Men: Days of Future Past",
+      "tvdb_id": 127585
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0413168",
+      "tvdb_id": 6968,
+      "name": "Hugh Jackman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1446192",
+      "votes": 182606,
+      "rating": 7.2,
+      "name": "Rise of the Guardians",
+      "tvdb_id": 81188
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000285",
+      "tvdb_id": 7447,
+      "name": "Alec Baldwin"
+    }
+  ]
+}

--- a/puzzles/2023-09-17.json
+++ b/puzzles/2023-09-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3392,
+  "target_tvdb_id": 4937,
+  "source_imdb_id": "nm0000140",
+  "target_imdb_id": "nm0000681",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0478970",
+      "votes": 689185,
+      "rating": 7.3,
+      "name": "Ant-Man",
+      "tvdb_id": 102899
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0357413",
+      "votes": 365542,
+      "rating": 7.1,
+      "name": "Anchorman: The Legend of Ron Burgundy",
+      "tvdb_id": 8699
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000681",
+      "tvdb_id": 4937,
+      "name": "Vince Vaughn"
+    }
+  ]
+}

--- a/puzzles/2023-09-18.json
+++ b/puzzles/2023-09-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 114,
+  "target_tvdb_id": 12835,
+  "source_imdb_id": "nm0089217",
+  "target_imdb_id": "nm0004874",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0089217",
+      "tvdb_id": 114,
+      "name": "Orlando Bloom"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0325980",
+      "votes": 1149544,
+      "rating": 8.1,
+      "name": "Pirates of the Caribbean: The Curse of the Black Pearl",
+      "tvdb_id": 22
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004874",
+      "tvdb_id": 12835,
+      "name": "Vin Diesel"
+    }
+  ]
+}

--- a/puzzles/2023-09-19.json
+++ b/puzzles/2023-09-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5530,
+  "target_tvdb_id": 114,
+  "source_imdb_id": "nm0564215",
+  "target_imdb_id": "nm0089217",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0564215",
+      "tvdb_id": 5530,
+      "name": "James McAvoy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1877832",
+      "votes": 723350,
+      "rating": 7.9,
+      "name": "X-Men: Days of Future Past",
+      "tvdb_id": 127585
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005212",
+      "tvdb_id": 1327,
+      "name": "Ian McKellen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1170358",
+      "votes": 677164,
+      "rating": 7.8,
+      "name": "The Hobbit: The Desolation of Smaug",
+      "tvdb_id": 57158
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0089217",
+      "tvdb_id": 114,
+      "name": "Orlando Bloom"
+    }
+  ]
+}

--- a/puzzles/2023-09-20.json
+++ b/puzzles/2023-09-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 569,
+  "target_tvdb_id": 71580,
+  "source_imdb_id": "nm0000160",
+  "target_imdb_id": "nm1212722",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000160",
+      "tvdb_id": 569,
+      "name": "Ethan Hawke"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt11138512",
+      "votes": 225973,
+      "rating": 7.0,
+      "name": "The Northman",
+      "tvdb_id": 639933
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt10872600",
+      "votes": 789409,
+      "rating": 8.2,
+      "name": "Spider-Man: No Way Home",
+      "tvdb_id": 634649
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1212722",
+      "tvdb_id": 71580,
+      "name": "Benedict Cumberbatch"
+    }
+  ]
+}

--- a/puzzles/2023-09-21.json
+++ b/puzzles/2023-09-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1532,
+  "target_tvdb_id": 13240,
+  "source_imdb_id": "nm0000195",
+  "target_imdb_id": "nm0000242",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000195",
+      "tvdb_id": 1532,
+      "name": "Bill Murray"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2177771",
+      "votes": 134538,
+      "rating": 6.1,
+      "name": "The Monuments Men",
+      "tvdb_id": 152760
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
+    }
+  ]
+}

--- a/puzzles/2023-09-22.json
+++ b/puzzles/2023-09-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2231,
+  "target_tvdb_id": 6968,
+  "source_imdb_id": "nm0000168",
+  "target_imdb_id": "nm0413168",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1843866",
+      "votes": 862951,
+      "rating": 7.8,
+      "name": "Captain America: The Winter Soldier",
+      "tvdb_id": 100402
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0482571",
+      "votes": 1359502,
+      "rating": 8.5,
+      "name": "The Prestige",
+      "tvdb_id": 1124
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0413168",
+      "tvdb_id": 6968,
+      "name": "Hugh Jackman"
+    }
+  ]
+}

--- a/puzzles/2023-09-23.json
+++ b/puzzles/2023-09-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 854,
+  "target_tvdb_id": 368,
+  "source_imdb_id": "nm0000071",
+  "target_imdb_id": "nm0000702",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000071",
+      "tvdb_id": 854,
+      "name": "James Stewart"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0107554",
+      "votes": 61419,
+      "rating": 7.5,
+      "name": "Menace II Society",
+      "tvdb_id": 9516
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0740951",
+      "tvdb_id": 43010,
+      "name": "Thomas Rosales Jr."
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2967224",
+      "votes": 52440,
+      "rating": 5.1,
+      "name": "Hot Pursuit",
+      "tvdb_id": 268920
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000702",
+      "tvdb_id": 368,
+      "name": "Reese Witherspoon"
+    }
+  ]
+}

--- a/puzzles/2023-09-24.json
+++ b/puzzles/2023-09-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 934,
+  "target_tvdb_id": 7447,
+  "source_imdb_id": "nm0000128",
+  "target_imdb_id": "nm0000285",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0758774",
+      "votes": 232618,
+      "rating": 7.0,
+      "name": "Body of Lies",
+      "tvdb_id": 12113
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000285",
+      "tvdb_id": 7447,
+      "name": "Alec Baldwin"
+    }
+  ]
+}

--- a/puzzles/2023-09-25.json
+++ b/puzzles/2023-09-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2888,
+  "target_tvdb_id": 3967,
+  "source_imdb_id": "nm0000226",
+  "target_imdb_id": "nm0000295",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000226",
+      "tvdb_id": 2888,
+      "name": "Will Smith"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1386697",
+      "votes": 697460,
+      "rating": 5.9,
+      "name": "Suicide Squad",
+      "tvdb_id": 297761
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0213149",
+      "votes": 339910,
+      "rating": 6.2,
+      "name": "Pearl Harbor",
+      "tvdb_id": 676
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000295",
+      "tvdb_id": 3967,
+      "name": "Kate Beckinsale"
+    }
+  ]
+}

--- a/puzzles/2023-09-26.json
+++ b/puzzles/2023-09-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 10297,
+  "target_tvdb_id": 3036,
+  "source_imdb_id": "nm0000190",
+  "target_imdb_id": "nm0000131",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000190",
+      "tvdb_id": 10297,
+      "name": "Matthew McConaughey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm2180792",
+      "tvdb_id": 86624,
+      "name": "Collette Wolfe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1231587",
+      "votes": 179559,
+      "rating": 6.4,
+      "name": "Hot Tub Time Machine",
+      "tvdb_id": 23048
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000131",
+      "tvdb_id": 3036,
+      "name": "John Cusack"
+    }
+  ]
+}

--- a/puzzles/2023-09-27.json
+++ b/puzzles/2023-09-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 12052,
+  "target_tvdb_id": 24045,
+  "source_imdb_id": "nm0000569",
+  "target_imdb_id": "nm0330687",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000569",
+      "tvdb_id": 12052,
+      "name": "Gwyneth Paltrow"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114369",
+      "votes": 1690351,
+      "rating": 8.6,
+      "name": "Se7en",
+      "tvdb_id": 807
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1345836",
+      "votes": 1735537,
+      "rating": 8.4,
+      "name": "The Dark Knight Rises",
+      "tvdb_id": 49026
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
+    }
+  ]
+}

--- a/puzzles/2023-09-28.json
+++ b/puzzles/2023-09-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3489,
+  "target_tvdb_id": 2176,
+  "source_imdb_id": "nm0915208",
+  "target_imdb_id": "nm0000169",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915208",
+      "tvdb_id": 3489,
+      "name": "Naomi Watts"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0298130",
+      "votes": 358944,
+      "rating": 7.1,
+      "name": "The Ring",
+      "tvdb_id": 565
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0132625",
+      "tvdb_id": 15318,
+      "name": "Keith Campbell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119654",
+      "votes": 582276,
+      "rating": 7.3,
+      "name": "Men in Black",
+      "tvdb_id": 607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
+    }
+  ]
+}

--- a/puzzles/2023-09-29.json
+++ b/puzzles/2023-09-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 449,
+  "target_tvdb_id": 819,
+  "source_imdb_id": "nm0059431",
+  "target_imdb_id": "nm0001570",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1234721",
+      "votes": 232999,
+      "rating": 6.1,
+      "name": "RoboCop",
+      "tvdb_id": 97020
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0340260",
+      "tvdb_id": 7471,
+      "name": "Zach Grenier"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0137523",
+      "votes": 2176824,
+      "rating": 8.8,
+      "name": "Fight Club",
+      "tvdb_id": 550
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001570",
+      "tvdb_id": 819,
+      "name": "Edward Norton"
+    }
+  ]
+}

--- a/puzzles/2023-09-30.json
+++ b/puzzles/2023-09-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 18999,
+  "target_tvdb_id": 738,
+  "source_imdb_id": "nm0799777",
+  "target_imdb_id": "nm0000125",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2582802",
+      "votes": 898359,
+      "rating": 8.5,
+      "name": "Whiplash",
+      "tvdb_id": 244786
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0333318",
+      "tvdb_id": 10691,
+      "name": "April Grace"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0181536",
+      "votes": 87627,
+      "rating": 7.3,
+      "name": "Finding Forrester",
+      "tvdb_id": 711
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000125",
+      "tvdb_id": 738,
+      "name": "Sean Connery"
+    }
+  ]
+}

--- a/puzzles/2023-10-01.json
+++ b/puzzles/2023-10-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 880,
+  "target_tvdb_id": 3,
+  "source_imdb_id": "nm0000255",
+  "target_imdb_id": "nm0000148",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2267998",
+      "votes": 1004941,
+      "rating": 8.1,
+      "name": "Gone Girl",
+      "tvdb_id": 210577
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000688",
+      "tvdb_id": 6068,
+      "name": "Sela Ward"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0106977",
+      "votes": 303662,
+      "rating": 7.8,
+      "name": "The Fugitive",
+      "tvdb_id": 5503
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
+    }
+  ]
+}

--- a/puzzles/2023-10-02.json
+++ b/puzzles/2023-10-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2963,
+  "target_tvdb_id": 880,
+  "source_imdb_id": "nm0000115",
+  "target_imdb_id": "nm0000255",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000115",
+      "tvdb_id": 2963,
+      "name": "Nicolas Cage"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt11291274",
+      "votes": 120284,
+      "rating": 7.0,
+      "name": "The Unbearable Weight of Massive Talent",
+      "tvdb_id": 648579
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000439",
+      "tvdb_id": 41686,
+      "name": "Neil Patrick Harris"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2267998",
+      "votes": 1004941,
+      "rating": 8.1,
+      "name": "Gone Girl",
+      "tvdb_id": 210577
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
+    }
+  ]
+}

--- a/puzzles/2023-10-03.json
+++ b/puzzles/2023-10-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 51329,
+  "target_tvdb_id": 514,
+  "source_imdb_id": "nm0177896",
+  "target_imdb_id": "nm0000197",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000335",
+      "tvdb_id": 515,
+      "name": "Glenn Close"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0116996",
+      "votes": 233754,
+      "rating": 6.4,
+      "name": "Mars Attacks!",
+      "tvdb_id": 75
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000197",
+      "tvdb_id": 514,
+      "name": "Jack Nicholson"
+    }
+  ]
+}

--- a/puzzles/2023-10-04.json
+++ b/puzzles/2023-10-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 27319,
+  "target_tvdb_id": 5293,
+  "source_imdb_id": "nm0910607",
+  "target_imdb_id": "nm0000353",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0910607",
+      "tvdb_id": 27319,
+      "name": "Christoph Waltz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt10872600",
+      "votes": 789409,
+      "rating": 8.2,
+      "name": "Spider-Man: No Way Home",
+      "tvdb_id": 634649
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    }
+  ]
+}

--- a/puzzles/2023-10-05.json
+++ b/puzzles/2023-10-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 44735,
+  "target_tvdb_id": 996701,
+  "source_imdb_id": "nm0251986",
+  "target_imdb_id": "nm1886602",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0251986",
+      "tvdb_id": 44735,
+      "name": "Jesse Eisenberg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt12361974",
+      "votes": 410571,
+      "rating": 8.0,
+      "name": "Zack Snyder's Justice League",
+      "tvdb_id": 791373
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2582802",
+      "votes": 898359,
+      "rating": 8.5,
+      "name": "Whiplash",
+      "tvdb_id": 244786
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1886602",
+      "tvdb_id": 996701,
+      "name": "Miles Teller"
+    }
+  ]
+}

--- a/puzzles/2023-10-06.json
+++ b/puzzles/2023-10-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 53714,
+  "target_tvdb_id": 5576,
+  "source_imdb_id": "nm1046097",
+  "target_imdb_id": "nm0000174",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1046097",
+      "tvdb_id": 53714,
+      "name": "Rachel McAdams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0988045",
+      "votes": 646635,
+      "rating": 7.6,
+      "name": "Sherlock Holmes",
+      "tvdb_id": 10528
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000375",
+      "tvdb_id": 3223,
+      "name": "Robert Downey Jr."
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0373469",
+      "votes": 231023,
+      "rating": 7.5,
+      "name": "Kiss Kiss Bang Bang",
+      "tvdb_id": 5236
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000174",
+      "tvdb_id": 5576,
+      "name": "Val Kilmer"
+    }
+  ]
+}

--- a/puzzles/2023-10-07.json
+++ b/puzzles/2023-10-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 30614,
+  "target_tvdb_id": 73968,
+  "source_imdb_id": "nm0331516",
+  "target_imdb_id": "nm0147147",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0331516",
+      "tvdb_id": 30614,
+      "name": "Ryan Gosling"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3799694",
+      "votes": 340579,
+      "rating": 7.3,
+      "name": "The Nice Guys",
+      "tvdb_id": 290250
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0770828",
+      "votes": 784138,
+      "rating": 7.1,
+      "name": "Man of Steel",
+      "tvdb_id": 49521
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
+    }
+  ]
+}

--- a/puzzles/2023-10-08.json
+++ b/puzzles/2023-10-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1892,
+  "target_tvdb_id": 18277,
+  "source_imdb_id": "nm0000354",
+  "target_imdb_id": "nm0000113",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0496806",
+      "votes": 354950,
+      "rating": 6.9,
+      "name": "Ocean's Thirteen",
+      "tvdb_id": 298
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1454468",
+      "votes": 838982,
+      "rating": 7.7,
+      "name": "Gravity",
+      "tvdb_id": 49047
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000113",
+      "tvdb_id": 18277,
+      "name": "Sandra Bullock"
+    }
+  ]
+}

--- a/puzzles/2023-10-09.json
+++ b/puzzles/2023-10-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 7399,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0001774",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0829482",
+      "votes": 597604,
+      "rating": 7.6,
+      "name": "Superbad",
+      "tvdb_id": 8363
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1298649",
+      "votes": 130165,
+      "rating": 5.7,
+      "name": "The Watch",
+      "tvdb_id": 80035
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001774",
+      "tvdb_id": 7399,
+      "name": "Ben Stiller"
+    }
+  ]
+}

--- a/puzzles/2023-10-10.json
+++ b/puzzles/2023-10-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1333,
+  "target_tvdb_id": 192,
+  "source_imdb_id": "nm0785227",
+  "target_imdb_id": "nm0000151",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0785227",
+      "tvdb_id": 1333,
+      "name": "Andy Serkis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0482571",
+      "votes": 1359502,
+      "rating": 8.5,
+      "name": "The Prestige",
+      "tvdb_id": 1124
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    }
+  ]
+}

--- a/puzzles/2023-10-11.json
+++ b/puzzles/2023-10-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1245,
+  "target_tvdb_id": 4756,
+  "source_imdb_id": "nm0424060",
+  "target_imdb_id": "nm0000111",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2872732",
+      "votes": 509899,
+      "rating": 6.4,
+      "name": "Lucy",
+      "tvdb_id": 240832
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0097441",
+      "votes": 138396,
+      "rating": 7.8,
+      "name": "Glory",
+      "tvdb_id": 9665
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000111",
+      "tvdb_id": 4756,
+      "name": "Matthew Broderick"
+    }
+  ]
+}

--- a/puzzles/2023-10-12.json
+++ b/puzzles/2023-10-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6968,
+  "target_tvdb_id": 5293,
+  "source_imdb_id": "nm0413168",
+  "target_imdb_id": "nm0000353",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0413168",
+      "tvdb_id": 6968,
+      "name": "Hugh Jackman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0482571",
+      "votes": 1359502,
+      "rating": 8.5,
+      "name": "The Prestige",
+      "tvdb_id": 1124
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0144084",
+      "votes": 651517,
+      "rating": 7.6,
+      "name": "American Psycho",
+      "tvdb_id": 1359
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    }
+  ]
+}

--- a/puzzles/2023-10-13.json
+++ b/puzzles/2023-10-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6730,
+  "target_tvdb_id": 1367,
+  "source_imdb_id": "nm0056187",
+  "target_imdb_id": "nm0397102",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0056187",
+      "tvdb_id": 6730,
+      "name": "Sacha Baron Cohen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0970179",
+      "votes": 328128,
+      "rating": 7.5,
+      "name": "Hugo",
+      "tvdb_id": 44826
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000489",
+      "tvdb_id": 113,
+      "name": "Christopher Lee"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120737",
+      "votes": 1909585,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Fellowship of the Ring",
+      "tvdb_id": 120
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0397102",
+      "tvdb_id": 1367,
+      "name": "Alan Howard"
+    }
+  ]
+}

--- a/puzzles/2023-10-14.json
+++ b/puzzles/2023-10-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1461,
+  "target_tvdb_id": 131,
+  "source_imdb_id": "nm0000123",
+  "target_imdb_id": "nm0350453",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1193138",
+      "votes": 341335,
+      "rating": 7.4,
+      "name": "Up in the Air",
+      "tvdb_id": 22947
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0267812",
+      "tvdb_id": 21657,
+      "name": "Vera Farmiga"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0945513",
+      "votes": 529835,
+      "rating": 7.5,
+      "name": "Source Code",
+      "tvdb_id": 45612
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0350453",
+      "tvdb_id": 131,
+      "name": "Jake Gyllenhaal"
+    }
+  ]
+}

--- a/puzzles/2023-10-15.json
+++ b/puzzles/2023-10-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 72466,
+  "target_tvdb_id": 1038,
+  "source_imdb_id": "nm0268199",
+  "target_imdb_id": "nm0000149",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0268199",
+      "tvdb_id": 72466,
+      "name": "Colin Farrell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0183649",
+      "votes": 275592,
+      "rating": 7.1,
+      "name": "Phone Booth",
+      "tvdb_id": 1817
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001845",
+      "tvdb_id": 2178,
+      "name": "Forest Whitaker"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0258000",
+      "votes": 285745,
+      "rating": 6.8,
+      "name": "Panic Room",
+      "tvdb_id": 4547
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000149",
+      "tvdb_id": 1038,
+      "name": "Jodie Foster"
+    }
+  ]
+}

--- a/puzzles/2023-10-16.json
+++ b/puzzles/2023-10-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 504,
+  "target_tvdb_id": 190,
+  "source_imdb_id": "nm0000209",
+  "target_imdb_id": "nm0000142",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000209",
+      "tvdb_id": 504,
+      "name": "Tim Robbins"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0111161",
+      "votes": 2734155,
+      "rating": 9.3,
+      "name": "The Shawshank Redemption",
+      "tvdb_id": 278
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0405159",
+      "votes": 698263,
+      "rating": 8.1,
+      "name": "Million Dollar Baby",
+      "tvdb_id": 70
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000142",
+      "tvdb_id": 190,
+      "name": "Clint Eastwood"
+    }
+  ]
+}

--- a/puzzles/2023-10-17.json
+++ b/puzzles/2023-10-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5472,
+  "target_tvdb_id": 1461,
+  "source_imdb_id": "nm0000147",
+  "target_imdb_id": "nm0000123",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000147",
+      "tvdb_id": 5472,
+      "name": "Colin Firth"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1504320",
+      "votes": 690511,
+      "rating": 8.0,
+      "name": "The King's Speech",
+      "tvdb_id": 45269
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0002091",
+      "tvdb_id": 5658,
+      "name": "Michael Gambon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0432283",
+      "votes": 243431,
+      "rating": 7.9,
+      "name": "Fantastic Mr. Fox",
+      "tvdb_id": 10315
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    }
+  ]
+}

--- a/puzzles/2023-10-18.json
+++ b/puzzles/2023-10-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 21657,
+  "target_tvdb_id": 6384,
+  "source_imdb_id": "nm0267812",
+  "target_imdb_id": "nm0000206",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0267812",
+      "tvdb_id": 21657,
+      "name": "Vera Farmiga"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000197",
+      "tvdb_id": 514,
+      "name": "Jack Nicholson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0337741",
+      "votes": 124856,
+      "rating": 6.7,
+      "name": "Something's Gotta Give",
+      "tvdb_id": 6964
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000206",
+      "tvdb_id": 6384,
+      "name": "Keanu Reeves"
+    }
+  ]
+}

--- a/puzzles/2023-10-19.json
+++ b/puzzles/2023-10-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1979,
+  "target_tvdb_id": 1245,
+  "source_imdb_id": "nm0000228",
+  "target_imdb_id": "nm0424060",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000228",
+      "tvdb_id": 1979,
+      "name": "Kevin Spacey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114369",
+      "votes": 1690351,
+      "rating": 8.6,
+      "name": "Se7en",
+      "tvdb_id": 807
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2872732",
+      "votes": 509899,
+      "rating": 6.4,
+      "name": "Lucy",
+      "tvdb_id": 240832
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
+    }
+  ]
+}

--- a/puzzles/2023-10-20.json
+++ b/puzzles/2023-10-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 449,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0059431",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0829482",
+      "votes": 597604,
+      "rating": 7.6,
+      "name": "Superbad",
+      "tvdb_id": 8363
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0892769",
+      "votes": 758216,
+      "rating": 8.1,
+      "name": "How to Train Your Dragon",
+      "tvdb_id": 10191
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
+    }
+  ]
+}

--- a/puzzles/2023-10-21.json
+++ b/puzzles/2023-10-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4,
+  "target_tvdb_id": 5472,
+  "source_imdb_id": "nm0000402",
+  "target_imdb_id": "nm0000147",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000402",
+      "tvdb_id": 4,
+      "name": "Carrie Fisher"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0076759",
+      "votes": 1388591,
+      "rating": 8.6,
+      "name": "Star Wars: Episode IV - A New Hope",
+      "tvdb_id": 11
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000434",
+      "tvdb_id": 2,
+      "name": "Mark Hamill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2802144",
+      "votes": 683363,
+      "rating": 7.7,
+      "name": "Kingsman: The Secret Service",
+      "tvdb_id": 207703
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000147",
+      "tvdb_id": 5472,
+      "name": "Colin Firth"
+    }
+  ]
+}

--- a/puzzles/2023-10-22.json
+++ b/puzzles/2023-10-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4785,
+  "target_tvdb_id": 5294,
+  "source_imdb_id": "nm0000156",
+  "target_imdb_id": "nm0252230",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000156",
+      "tvdb_id": 4785,
+      "name": "Jeff Goldblum"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3501632",
+      "votes": 771855,
+      "rating": 7.9,
+      "name": "Thor: Ragnarok",
+      "tvdb_id": 284053
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1212722",
+      "tvdb_id": 71580,
+      "name": "Benedict Cumberbatch"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1211837",
+      "votes": 761886,
+      "rating": 7.5,
+      "name": "Doctor Strange",
+      "tvdb_id": 284052
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0252230",
+      "tvdb_id": 5294,
+      "name": "Chiwetel Ejiofor"
+    }
+  ]
+}

--- a/puzzles/2023-10-23.json
+++ b/puzzles/2023-10-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 10859,
+  "target_tvdb_id": 1892,
+  "source_imdb_id": "nm0005351",
+  "target_imdb_id": "nm0000354",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005351",
+      "tvdb_id": 10859,
+      "name": "Ryan Reynolds"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0475394",
+      "votes": 148228,
+      "rating": 6.6,
+      "name": "Smokin' Aces",
+      "tvdb_id": 7516
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119217",
+      "votes": 998916,
+      "rating": 8.3,
+      "name": "Good Will Hunting",
+      "tvdb_id": 489
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    }
+  ]
+}

--- a/puzzles/2023-10-24.json
+++ b/puzzles/2023-10-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6941,
+  "target_tvdb_id": 8891,
+  "source_imdb_id": "nm0000139",
+  "target_imdb_id": "nm0000237",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000139",
+      "tvdb_id": 6941,
+      "name": "Cameron Diaz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110475",
+      "votes": 397469,
+      "rating": 6.9,
+      "name": "The Mask",
+      "tvdb_id": 854
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0338886",
+      "tvdb_id": 11803,
+      "name": "Peter Greene"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000237",
+      "tvdb_id": 8891,
+      "name": "John Travolta"
+    }
+  ]
+}

--- a/puzzles/2023-10-25.json
+++ b/puzzles/2023-10-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 996701,
+  "target_tvdb_id": 5469,
+  "source_imdb_id": "nm1886602",
+  "target_imdb_id": "nm0000146",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1886602",
+      "tvdb_id": 996701,
+      "name": "Miles Teller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1745960",
+      "votes": 577408,
+      "rating": 8.3,
+      "name": "Top Gun: Maverick",
+      "tvdb_id": 361743
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000174",
+      "tvdb_id": 5576,
+      "name": "Val Kilmer"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120794",
+      "votes": 137962,
+      "rating": 7.2,
+      "name": "The Prince of Egypt",
+      "tvdb_id": 9837
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000146",
+      "tvdb_id": 5469,
+      "name": "Ralph Fiennes"
+    }
+  ]
+}

--- a/puzzles/2023-10-26.json
+++ b/puzzles/2023-10-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1204,
+  "target_tvdb_id": 12073,
+  "source_imdb_id": "nm0000210",
+  "target_imdb_id": "nm0000196",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000210",
+      "tvdb_id": 1204,
+      "name": "Julia Roberts"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0349903",
+      "votes": 399386,
+      "rating": 6.5,
+      "name": "Ocean's Twelve",
+      "tvdb_id": 163
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000196",
+      "tvdb_id": 12073,
+      "name": "Mike Myers"
+    }
+  ]
+}

--- a/puzzles/2023-10-27.json
+++ b/puzzles/2023-10-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 21007,
+  "target_tvdb_id": 1229,
+  "source_imdb_id": "nm1706767",
+  "target_imdb_id": "nm0000313",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0993846",
+      "votes": 1455112,
+      "rating": 8.2,
+      "name": "The Wolf of Wall Street",
+      "tvdb_id": 106646
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0269463",
+      "tvdb_id": 15277,
+      "name": "Jon Favreau"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0371746",
+      "votes": 1078315,
+      "rating": 7.9,
+      "name": "Iron Man",
+      "tvdb_id": 1726
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000313",
+      "tvdb_id": 1229,
+      "name": "Jeff Bridges"
+    }
+  ]
+}

--- a/puzzles/2023-10-28.json
+++ b/puzzles/2023-10-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 73421,
+  "target_tvdb_id": 16483,
+  "source_imdb_id": "nm0001618",
+  "target_imdb_id": "nm0000230",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001618",
+      "tvdb_id": 73421,
+      "name": "Joaquin Phoenix"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1798709",
+      "votes": 632987,
+      "rating": 8.0,
+      "name": "Her",
+      "tvdb_id": 152601
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0695435",
+      "tvdb_id": 73457,
+      "name": "Chris Pratt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3896198",
+      "votes": 700926,
+      "rating": 7.6,
+      "name": "Guardians of the Galaxy Vol. 2",
+      "tvdb_id": 283995
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000230",
+      "tvdb_id": 16483,
+      "name": "Sylvester Stallone"
+    }
+  ]
+}

--- a/puzzles/2023-10-29.json
+++ b/puzzles/2023-10-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 134,
+  "target_tvdb_id": 10959,
+  "source_imdb_id": "nm0004937",
+  "target_imdb_id": "nm0479471",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001664",
+      "tvdb_id": 1736,
+      "name": "James Remar"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1399103",
+      "votes": 416771,
+      "rating": 6.2,
+      "name": "Transformers: Dark of the Moon",
+      "tvdb_id": 38356
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0479471",
+      "tvdb_id": 10959,
+      "name": "Shia LaBeouf"
+    }
+  ]
+}

--- a/puzzles/2023-10-30.json
+++ b/puzzles/2023-10-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2283,
+  "target_tvdb_id": 23532,
+  "source_imdb_id": "nm0001804",
+  "target_imdb_id": "nm0000867",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001804",
+      "tvdb_id": 2283,
+      "name": "Stanley Tucci"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1392170",
+      "votes": 943735,
+      "rating": 7.2,
+      "name": "The Hunger Games",
+      "tvdb_id": 70160
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000661",
+      "tvdb_id": 55636,
+      "name": "Donald Sutherland"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1499658",
+      "votes": 456972,
+      "rating": 6.9,
+      "name": "Horrible Bosses",
+      "tvdb_id": 51540
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000867",
+      "tvdb_id": 23532,
+      "name": "Jason Bateman"
+    }
+  ]
+}

--- a/puzzles/2023-10-31.json
+++ b/puzzles/2023-10-31.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2975,
+  "target_tvdb_id": 71580,
+  "source_imdb_id": "nm0000401",
+  "target_imdb_id": "nm1212722",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000401",
+      "tvdb_id": 2975,
+      "name": "Laurence Fishburne"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0133093",
+      "votes": 1950577,
+      "rating": 8.7,
+      "name": "The Matrix",
+      "tvdb_id": 603
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915989",
+      "tvdb_id": 1331,
+      "name": "Hugo Weaving"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0903624",
+      "votes": 842123,
+      "rating": 7.8,
+      "name": "The Hobbit: An Unexpected Journey",
+      "tvdb_id": 49051
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1212722",
+      "tvdb_id": 71580,
+      "name": "Benedict Cumberbatch"
+    }
+  ]
+}

--- a/puzzles/2023-11-01.json
+++ b/puzzles/2023-11-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 74568,
+  "target_tvdb_id": 9560,
+  "source_imdb_id": "nm1165110",
+  "target_imdb_id": "nm0000995",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1165110",
+      "tvdb_id": 74568,
+      "name": "Chris Hemsworth"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3501632",
+      "votes": 771855,
+      "rating": 7.9,
+      "name": "Thor: Ragnarok",
+      "tvdb_id": 284053
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
+    }
+  ]
+}

--- a/puzzles/2023-11-02.json
+++ b/puzzles/2023-11-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1979,
+  "target_tvdb_id": 8691,
+  "source_imdb_id": "nm0000228",
+  "target_imdb_id": "nm0757855",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000228",
+      "tvdb_id": 1979,
+      "name": "Kevin Spacey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114814",
+      "votes": 1101412,
+      "rating": 8.5,
+      "name": "The Usual Suspects",
+      "tvdb_id": 629
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001125",
+      "tvdb_id": 1121,
+      "name": "Benicio Del Toro"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    }
+  ]
+}

--- a/puzzles/2023-11-03.json
+++ b/puzzles/2023-11-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 193,
+  "target_tvdb_id": 6941,
+  "source_imdb_id": "nm0000432",
+  "target_imdb_id": "nm0000139",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000432",
+      "tvdb_id": 193,
+      "name": "Gene Hackman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0265666",
+      "votes": 300100,
+      "rating": 7.6,
+      "name": "The Royal Tenenbaums",
+      "tvdb_id": 9428
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001774",
+      "tvdb_id": 7399,
+      "name": "Ben Stiller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0129387",
+      "votes": 318188,
+      "rating": 7.1,
+      "name": "There's Something About Mary",
+      "tvdb_id": 544
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000139",
+      "tvdb_id": 6941,
+      "name": "Cameron Diaz"
+    }
+  ]
+}

--- a/puzzles/2023-11-04.json
+++ b/puzzles/2023-11-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 10297,
+  "target_tvdb_id": 8691,
+  "source_imdb_id": "nm0000190",
+  "target_imdb_id": "nm0757855",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000190",
+      "tvdb_id": 10297,
+      "name": "Matthew McConaughey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3470600",
+      "votes": 177756,
+      "rating": 7.1,
+      "name": "Sing",
+      "tvdb_id": 335797
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000604",
+      "tvdb_id": 4764,
+      "name": "John C. Reilly"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    }
+  ]
+}

--- a/puzzles/2023-11-05.json
+++ b/puzzles/2023-11-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1158,
+  "target_tvdb_id": 2963,
+  "source_imdb_id": "nm0000199",
+  "target_imdb_id": "nm0000115",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0071562",
+      "votes": 1296165,
+      "rating": 9.0,
+      "name": "The Godfather Part II",
+      "tvdb_id": 240
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000380",
+      "tvdb_id": 3087,
+      "name": "Robert Duvall"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0187078",
+      "votes": 285011,
+      "rating": 6.5,
+      "name": "Gone in 60 Seconds",
+      "tvdb_id": 9679
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000115",
+      "tvdb_id": 2963,
+      "name": "Nicolas Cage"
+    }
+  ]
+}

--- a/puzzles/2023-11-06.json
+++ b/puzzles/2023-11-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 103,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0749263",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1156398",
+      "votes": 593204,
+      "rating": 7.6,
+      "name": "Zombieland",
+      "tvdb_id": 19908
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0251986",
+      "tvdb_id": 44735,
+      "name": "Jesse Eisenberg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1670345",
+      "votes": 676146,
+      "rating": 7.2,
+      "name": "Now You See Me",
+      "tvdb_id": 75656
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
+    }
+  ]
+}

--- a/puzzles/2023-11-07.json
+++ b/puzzles/2023-11-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 72129,
+  "target_tvdb_id": 3895,
+  "source_imdb_id": "nm2225369",
+  "target_imdb_id": "nm0000323",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm2225369",
+      "tvdb_id": 72129,
+      "name": "Jennifer Lawrence"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1800241",
+      "votes": 487634,
+      "rating": 7.2,
+      "name": "American Hustle",
+      "tvdb_id": 168672
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    }
+  ]
+}

--- a/puzzles/2023-11-08.json
+++ b/puzzles/2023-11-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 30614,
+  "target_tvdb_id": 74568,
+  "source_imdb_id": "nm0331516",
+  "target_imdb_id": "nm1165110",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0331516",
+      "tvdb_id": 30614,
+      "name": "Ryan Gosling"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1649418",
+      "votes": 214927,
+      "rating": 6.5,
+      "name": "The Gray Man",
+      "tvdb_id": 725201
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0262635",
+      "tvdb_id": 16828,
+      "name": "Chris Evans"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0848228",
+      "votes": 1411541,
+      "rating": 8.0,
+      "name": "The Avengers",
+      "tvdb_id": 24428
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1165110",
+      "tvdb_id": 74568,
+      "name": "Chris Hemsworth"
+    }
+  ]
+}

--- a/puzzles/2023-11-09.json
+++ b/puzzles/2023-11-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 530,
+  "target_tvdb_id": 8784,
+  "source_imdb_id": "nm0005251",
+  "target_imdb_id": "nm0185819",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005251",
+      "tvdb_id": 530,
+      "name": "Carrie-Anne Moss"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0241303",
+      "votes": 195695,
+      "rating": 7.3,
+      "name": "Chocolat",
+      "tvdb_id": 392
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001132",
+      "tvdb_id": 5309,
+      "name": "Judi Dench"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1074638",
+      "votes": 708153,
+      "rating": 7.8,
+      "name": "Skyfall",
+      "tvdb_id": 37724
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0185819",
+      "tvdb_id": 8784,
+      "name": "Daniel Craig"
+    }
+  ]
+}

--- a/puzzles/2023-11-10.json
+++ b/puzzles/2023-11-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 12898,
+  "target_tvdb_id": 17178,
+  "source_imdb_id": "nm0000741",
+  "target_imdb_id": "nm0933940",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000741",
+      "tvdb_id": 12898,
+      "name": "Tim Allen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120363",
+      "votes": 593599,
+      "rating": 7.9,
+      "name": "Toy Story 2",
+      "tvdb_id": 863
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0123553",
+      "tvdb_id": 35219,
+      "name": "Corey Burton"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0429493",
+      "votes": 262991,
+      "rating": 6.7,
+      "name": "The A-Team",
+      "tvdb_id": 34544
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0933940",
+      "tvdb_id": 17178,
+      "name": "Patrick Wilson"
+    }
+  ]
+}

--- a/puzzles/2023-11-11.json
+++ b/puzzles/2023-11-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6193,
+  "target_tvdb_id": 13,
+  "source_imdb_id": "nm0000138",
+  "target_imdb_id": "nm0000983",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338751",
+      "votes": 370181,
+      "rating": 7.5,
+      "name": "The Aviator",
+      "tvdb_id": 2567
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0266543",
+      "votes": 1062914,
+      "rating": 8.2,
+      "name": "Finding Nemo",
+      "tvdb_id": 12
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000983",
+      "tvdb_id": 13,
+      "name": "Albert Brooks"
+    }
+  ]
+}

--- a/puzzles/2023-11-12.json
+++ b/puzzles/2023-11-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 30614,
+  "target_tvdb_id": 368,
+  "source_imdb_id": "nm0331516",
+  "target_imdb_id": "nm0000702",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0331516",
+      "tvdb_id": 30614,
+      "name": "Ryan Gosling"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1596363",
+      "votes": 444986,
+      "rating": 7.8,
+      "name": "The Big Short",
+      "tvdb_id": 318846
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0144084",
+      "votes": 651517,
+      "rating": 7.6,
+      "name": "American Psycho",
+      "tvdb_id": 1359
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000702",
+      "tvdb_id": 368,
+      "name": "Reese Witherspoon"
+    }
+  ]
+}

--- a/puzzles/2023-11-13.json
+++ b/puzzles/2023-11-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17276,
+  "target_tvdb_id": 1204,
+  "source_imdb_id": "nm0124930",
+  "target_imdb_id": "nm0000210",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0124930",
+      "tvdb_id": 17276,
+      "name": "Gerard Butler"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0416449",
+      "votes": 834419,
+      "rating": 7.6,
+      "name": "300",
+      "tvdb_id": 1271
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0922035",
+      "tvdb_id": 17287,
+      "name": "Dominic West"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2241351",
+      "votes": 102077,
+      "rating": 6.5,
+      "name": "Money Monster",
+      "tvdb_id": 303858
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000210",
+      "tvdb_id": 1204,
+      "name": "Julia Roberts"
+    }
+  ]
+}

--- a/puzzles/2023-11-14.json
+++ b/puzzles/2023-11-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5292,
+  "target_tvdb_id": 7060,
+  "source_imdb_id": "nm0000243",
+  "target_imdb_id": "nm0293509",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000243",
+      "tvdb_id": 5292,
+      "name": "Denzel Washington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0765429",
+      "votes": 434997,
+      "rating": 7.8,
+      "name": "American Gangster",
+      "tvdb_id": 4982
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0252230",
+      "tvdb_id": 5294,
+      "name": "Chiwetel Ejiofor"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0314331",
+      "votes": 502629,
+      "rating": 7.6,
+      "name": "Love Actually",
+      "tvdb_id": 508
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0293509",
+      "tvdb_id": 7060,
+      "name": "Martin Freeman"
+    }
+  ]
+}

--- a/puzzles/2023-11-15.json
+++ b/puzzles/2023-11-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 27578,
+  "target_tvdb_id": 2231,
+  "source_imdb_id": "nm0680983",
+  "target_imdb_id": "nm0000168",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0680983",
+      "tvdb_id": 27578,
+      "name": "Elliot Page"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    }
+  ]
+}

--- a/puzzles/2023-11-16.json
+++ b/puzzles/2023-11-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 12073,
+  "target_tvdb_id": 934,
+  "source_imdb_id": "nm0000196",
+  "target_imdb_id": "nm0000128",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000196",
+      "tvdb_id": 12073,
+      "name": "Mike Myers"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0295178",
+      "votes": 215087,
+      "rating": 6.2,
+      "name": "Austin Powers in Goldmember",
+      "tvdb_id": 818
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000228",
+      "tvdb_id": 1979,
+      "name": "Kevin Spacey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119488",
+      "votes": 591644,
+      "rating": 8.2,
+      "name": "L.A. Confidential",
+      "tvdb_id": 2118
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    }
+  ]
+}

--- a/puzzles/2023-11-17.json
+++ b/puzzles/2023-11-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 53714,
+  "target_tvdb_id": 12835,
+  "source_imdb_id": "nm1046097",
+  "target_imdb_id": "nm0004874",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1046097",
+      "tvdb_id": 53714,
+      "name": "Rachel McAdams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0396269",
+      "votes": 364100,
+      "rating": 7.0,
+      "name": "Wedding Crashers",
+      "tvdb_id": 9522
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004874",
+      "tvdb_id": 12835,
+      "name": "Vin Diesel"
+    }
+  ]
+}

--- a/puzzles/2023-11-18.json
+++ b/puzzles/2023-11-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 887,
+  "target_tvdb_id": 134,
+  "source_imdb_id": "nm0005562",
+  "target_imdb_id": "nm0004937",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005562",
+      "tvdb_id": 887,
+      "name": "Owen Wilson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3606752",
+      "votes": 107575,
+      "rating": 6.7,
+      "name": "Cars 3",
+      "tvdb_id": 260514
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0913488",
+      "tvdb_id": 11703,
+      "name": "Kerry Washington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    }
+  ]
+}

--- a/puzzles/2023-11-19.json
+++ b/puzzles/2023-11-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1038,
+  "target_tvdb_id": 22226,
+  "source_imdb_id": "nm0000149",
+  "target_imdb_id": "nm0748620",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000149",
+      "tvdb_id": 1038,
+      "name": "Jodie Foster"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0102926",
+      "votes": 1462039,
+      "rating": 8.6,
+      "name": "The Silence of the Lambs",
+      "tvdb_id": 274
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm2738436",
+      "tvdb_id": 1098036,
+      "name": "John W. Iwanonkiw"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1659337",
+      "votes": 524768,
+      "rating": 7.9,
+      "name": "The Perks of Being a Wallflower",
+      "tvdb_id": 84892
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
+    }
+  ]
+}

--- a/puzzles/2023-11-20.json
+++ b/puzzles/2023-11-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 504,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0000209",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1156398",
+      "votes": 593204,
+      "rating": 7.6,
+      "name": "Zombieland",
+      "tvdb_id": 19908
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm4798882",
+      "tvdb_id": null,
+      "name": "Brad Jacobowitz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0111161",
+      "votes": 2734155,
+      "rating": 9.3,
+      "name": "The Shawshank Redemption",
+      "tvdb_id": 278
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000209",
+      "tvdb_id": 504,
+      "name": "Tim Robbins"
+    }
+  ]
+}

--- a/puzzles/2023-11-21.json
+++ b/puzzles/2023-11-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3036,
+  "target_tvdb_id": 1813,
+  "source_imdb_id": "nm0000131",
+  "target_imdb_id": "nm0004266",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000131",
+      "tvdb_id": 3036,
+      "name": "John Cusack"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1190080",
+      "votes": 385247,
+      "rating": 5.8,
+      "name": "2012",
+      "tvdb_id": 14161
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001624",
+      "tvdb_id": 17485,
+      "name": "Oliver Platt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0758752",
+      "votes": 210456,
+      "rating": 6.7,
+      "name": "Love & Other Drugs",
+      "tvdb_id": 43347
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004266",
+      "tvdb_id": 1813,
+      "name": "Anne Hathaway"
+    }
+  ]
+}

--- a/puzzles/2023-11-22.json
+++ b/puzzles/2023-11-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1245,
+  "target_tvdb_id": 9560,
+  "source_imdb_id": "nm0424060",
+  "target_imdb_id": "nm0000995",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0482571",
+      "votes": 1359502,
+      "rating": 8.5,
+      "name": "The Prestige",
+      "tvdb_id": 1124
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
+    }
+  ]
+}

--- a/puzzles/2023-11-23.json
+++ b/puzzles/2023-11-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 9273,
+  "target_tvdb_id": 1229,
+  "source_imdb_id": "nm0010736",
+  "target_imdb_id": "nm0000313",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0918927",
+      "votes": 132559,
+      "rating": 7.5,
+      "name": "Doubt",
+      "tvdb_id": 14359
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000450",
+      "tvdb_id": 1233,
+      "name": "Philip Seymour Hoffman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0118715",
+      "votes": 824543,
+      "rating": 8.1,
+      "name": "The Big Lebowski",
+      "tvdb_id": 115
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000313",
+      "tvdb_id": 1229,
+      "name": "Jeff Bridges"
+    }
+  ]
+}

--- a/puzzles/2023-11-24.json
+++ b/puzzles/2023-11-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 23532,
+  "target_tvdb_id": 9560,
+  "source_imdb_id": "nm0000867",
+  "target_imdb_id": "nm0000995",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000867",
+      "tvdb_id": 23532,
+      "name": "Jason Bateman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0942385",
+      "votes": 427941,
+      "rating": 7.1,
+      "name": "Tropic Thunder",
+      "tvdb_id": 7446
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000190",
+      "tvdb_id": 10297,
+      "name": "Matthew McConaughey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
+    }
+  ]
+}

--- a/puzzles/2023-11-25.json
+++ b/puzzles/2023-11-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 8691,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0757855",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1243974",
+      "votes": 68574,
+      "rating": 5.4,
+      "name": "Aloha",
+      "tvdb_id": 222936
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    }
+  ]
+}

--- a/puzzles/2023-11-26.json
+++ b/puzzles/2023-11-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 934,
+  "target_tvdb_id": 996701,
+  "source_imdb_id": "nm0000128",
+  "target_imdb_id": "nm1886602",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0268978",
+      "votes": 947632,
+      "rating": 8.2,
+      "name": "A Beautiful Mind",
+      "tvdb_id": 453
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000124",
+      "tvdb_id": 6161,
+      "name": "Jennifer Connelly"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1745960",
+      "votes": 577408,
+      "rating": 8.3,
+      "name": "Top Gun: Maverick",
+      "tvdb_id": 361743
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1886602",
+      "tvdb_id": 996701,
+      "name": "Miles Teller"
+    }
+  ]
+}

--- a/puzzles/2023-11-27.json
+++ b/puzzles/2023-11-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4785,
+  "target_tvdb_id": 3129,
+  "source_imdb_id": "nm0000156",
+  "target_imdb_id": "nm0000619",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000156",
+      "tvdb_id": 4785,
+      "name": "Jeff Goldblum"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0107290",
+      "votes": 1010271,
+      "rating": 8.2,
+      "name": "Jurassic Park",
+      "tvdb_id": 329
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000619",
+      "tvdb_id": 3129,
+      "name": "Tim Roth"
+    }
+  ]
+}

--- a/puzzles/2023-11-28.json
+++ b/puzzles/2023-11-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 228,
+  "target_tvdb_id": 4937,
+  "source_imdb_id": "nm0000438",
+  "target_imdb_id": "nm0000681",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000438",
+      "tvdb_id": 228,
+      "name": "Ed Harris"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0268978",
+      "votes": 947632,
+      "rating": 8.2,
+      "name": "A Beautiful Mind",
+      "tvdb_id": 453
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000124",
+      "tvdb_id": 6161,
+      "name": "Jennifer Connelly"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1578275",
+      "votes": 55373,
+      "rating": 5.3,
+      "name": "The Dilemma",
+      "tvdb_id": 44564
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000681",
+      "tvdb_id": 4937,
+      "name": "Vince Vaughn"
+    }
+  ]
+}

--- a/puzzles/2023-11-29.json
+++ b/puzzles/2023-11-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 134,
+  "target_tvdb_id": 17178,
+  "source_imdb_id": "nm0004937",
+  "target_imdb_id": "nm0933940",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0947802",
+      "votes": 53857,
+      "rating": 6.2,
+      "name": "Lakeview Terrace",
+      "tvdb_id": 13279
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0933940",
+      "tvdb_id": 17178,
+      "name": "Patrick Wilson"
+    }
+  ]
+}

--- a/puzzles/2023-11-30.json
+++ b/puzzles/2023-11-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 7399,
+  "target_tvdb_id": 4,
+  "source_imdb_id": "nm0001774",
+  "target_imdb_id": "nm0000402",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001774",
+      "tvdb_id": 7399,
+      "name": "Ben Stiller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0196229",
+      "votes": 280270,
+      "rating": 6.5,
+      "name": "Zoolander",
+      "tvdb_id": 9398
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0295103",
+      "tvdb_id": 52860,
+      "name": "Judah Friedlander"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2488496",
+      "votes": 944891,
+      "rating": 7.8,
+      "name": "Star Wars: Episode VII - The Force Awakens",
+      "tvdb_id": 140607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000402",
+      "tvdb_id": 4,
+      "name": "Carrie Fisher"
+    }
+  ]
+}

--- a/puzzles/2023-12-01.json
+++ b/puzzles/2023-12-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3084,
+  "target_tvdb_id": 12073,
+  "source_imdb_id": "nm0000008",
+  "target_imdb_id": "nm0000196",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000008",
+      "tvdb_id": 3084,
+      "name": "Marlon Brando"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0078788",
+      "votes": 680101,
+      "rating": 8.5,
+      "name": "Apocalypse Now",
+      "tvdb_id": 28
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0131974",
+      "tvdb_id": 13023,
+      "name": "Colleen Camp"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0105793",
+      "votes": 162920,
+      "rating": 7.0,
+      "name": "Wayne's World",
+      "tvdb_id": 8872
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000196",
+      "tvdb_id": 12073,
+      "name": "Mike Myers"
+    }
+  ]
+}

--- a/puzzles/2023-12-02.json
+++ b/puzzles/2023-12-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 114,
+  "target_tvdb_id": 3489,
+  "source_imdb_id": "nm0089217",
+  "target_imdb_id": "nm0915208",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0089217",
+      "tvdb_id": 114,
+      "name": "Orlando Bloom"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120737",
+      "votes": 1909585,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Fellowship of the Ring",
+      "tvdb_id": 120
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0785227",
+      "tvdb_id": 1333,
+      "name": "Andy Serkis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0360717",
+      "votes": 432227,
+      "rating": 7.2,
+      "name": "King Kong",
+      "tvdb_id": 254
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915208",
+      "tvdb_id": 3489,
+      "name": "Naomi Watts"
+    }
+  ]
+}

--- a/puzzles/2023-12-03.json
+++ b/puzzles/2023-12-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1231,
+  "target_tvdb_id": 44735,
+  "source_imdb_id": "nm0000194",
+  "target_imdb_id": "nm0251986",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000194",
+      "tvdb_id": 1231,
+      "name": "Julianne Moore"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1570728",
+      "votes": 532097,
+      "rating": 7.4,
+      "name": "Crazy, Stupid, Love.",
+      "tvdb_id": 50646
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1156398",
+      "votes": 593204,
+      "rating": 7.6,
+      "name": "Zombieland",
+      "tvdb_id": 19908
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0251986",
+      "tvdb_id": 44735,
+      "name": "Jesse Eisenberg"
+    }
+  ]
+}

--- a/puzzles/2023-12-04.json
+++ b/puzzles/2023-12-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1229,
+  "target_tvdb_id": 976,
+  "source_imdb_id": "nm0000313",
+  "target_imdb_id": "nm0005458",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000313",
+      "tvdb_id": 1229,
+      "name": "Jeff Bridges"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2582782",
+      "votes": 238077,
+      "rating": 7.6,
+      "name": "Hell or High Water",
+      "tvdb_id": 338766
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004936",
+      "tvdb_id": 11107,
+      "name": "Ben Foster"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0472399",
+      "votes": 164559,
+      "rating": 6.5,
+      "name": "The Mechanic",
+      "tvdb_id": 27582
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005458",
+      "tvdb_id": 976,
+      "name": "Jason Statham"
+    }
+  ]
+}

--- a/puzzles/2023-12-05.json
+++ b/puzzles/2023-12-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3489,
+  "target_tvdb_id": 1461,
+  "source_imdb_id": "nm0915208",
+  "target_imdb_id": "nm0000123",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915208",
+      "tvdb_id": 3489,
+      "name": "Naomi Watts"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1649419",
+      "votes": 230096,
+      "rating": 7.5,
+      "name": "The Impossible",
+      "tvdb_id": 80278
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1234548",
+      "votes": 134848,
+      "rating": 6.2,
+      "name": "The Men Who Stare at Goats",
+      "tvdb_id": 10313
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    }
+  ]
+}

--- a/puzzles/2023-12-06.json
+++ b/puzzles/2023-12-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 18918,
+  "target_tvdb_id": 192,
+  "source_imdb_id": "nm0425005",
+  "target_imdb_id": "nm0000151",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0425005",
+      "tvdb_id": 18918,
+      "name": "Dwayne Johnson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1397514",
+      "votes": 107542,
+      "rating": 5.7,
+      "name": "Journey 2: The Mysterious Island",
+      "tvdb_id": 72545
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    }
+  ]
+}

--- a/puzzles/2023-12-07.json
+++ b/puzzles/2023-12-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 9560,
+  "target_tvdb_id": 3061,
+  "source_imdb_id": "nm0000995",
+  "target_imdb_id": "nm0000191",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm5857646",
+      "tvdb_id": 1360008,
+      "name": "Joseph Oliveira"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0399201",
+      "votes": 320598,
+      "rating": 6.8,
+      "name": "The Island",
+      "tvdb_id": 1635
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
+    }
+  ]
+}

--- a/puzzles/2023-12-08.json
+++ b/puzzles/2023-12-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5576,
+  "target_tvdb_id": 5294,
+  "source_imdb_id": "nm0000174",
+  "target_imdb_id": "nm0252230",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000174",
+      "tvdb_id": 5576,
+      "name": "Val Kilmer"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0453467",
+      "votes": 317076,
+      "rating": 7.1,
+      "name": "Deja Vu",
+      "tvdb_id": 7551
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000243",
+      "tvdb_id": 5292,
+      "name": "Denzel Washington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0765429",
+      "votes": 434997,
+      "rating": 7.8,
+      "name": "American Gangster",
+      "tvdb_id": 4982
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0252230",
+      "tvdb_id": 5294,
+      "name": "Chiwetel Ejiofor"
+    }
+  ]
+}

--- a/puzzles/2023-12-09.json
+++ b/puzzles/2023-12-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 54693,
+  "target_tvdb_id": 4,
+  "source_imdb_id": "nm1297015",
+  "target_imdb_id": "nm0000402",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1297015",
+      "tvdb_id": 54693,
+      "name": "Emma Stone"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3228774",
+      "votes": 243349,
+      "rating": 7.3,
+      "name": "Cruella",
+      "tvdb_id": 337404
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0063311",
+      "tvdb_id": 110075,
+      "name": "Paul Bazely"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2527336",
+      "votes": 645544,
+      "rating": 6.9,
+      "name": "Star Wars: Episode VIII - The Last Jedi",
+      "tvdb_id": 181808
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000402",
+      "tvdb_id": 4,
+      "name": "Carrie Fisher"
+    }
+  ]
+}

--- a/puzzles/2023-12-10.json
+++ b/puzzles/2023-12-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 854,
+  "target_tvdb_id": 62,
+  "source_imdb_id": "nm0000071",
+  "target_imdb_id": "nm0000246",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000071",
+      "tvdb_id": 854,
+      "name": "James Stewart"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0107554",
+      "votes": 61419,
+      "rating": 7.5,
+      "name": "Menace II Society",
+      "tvdb_id": 9516
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000246",
+      "tvdb_id": 62,
+      "name": "Bruce Willis"
+    }
+  ]
+}

--- a/puzzles/2023-12-11.json
+++ b/puzzles/2023-12-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4483,
+  "target_tvdb_id": 62,
+  "source_imdb_id": "nm0000163",
+  "target_imdb_id": "nm0000246",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000163",
+      "tvdb_id": 4483,
+      "name": "Dustin Hoffman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1302011",
+      "votes": 296968,
+      "rating": 7.2,
+      "name": "Kung Fu Panda 2",
+      "tvdb_id": 49444
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000198",
+      "tvdb_id": 64,
+      "name": "Gary Oldman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119116",
+      "votes": 484439,
+      "rating": 7.6,
+      "name": "The Fifth Element",
+      "tvdb_id": 18
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000246",
+      "tvdb_id": 62,
+      "name": "Bruce Willis"
+    }
+  ]
+}

--- a/puzzles/2023-12-12.json
+++ b/puzzles/2023-12-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2440,
+  "target_tvdb_id": 1229,
+  "source_imdb_id": "nm0631490",
+  "target_imdb_id": "nm0000313",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0631490",
+      "tvdb_id": 2440,
+      "name": "Bill Nighy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2194499",
+      "votes": 362937,
+      "rating": 7.8,
+      "name": "About Time",
+      "tvdb_id": 122906
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1727304",
+      "tvdb_id": 93210,
+      "name": "Domhnall Gleeson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1403865",
+      "votes": 346030,
+      "rating": 7.6,
+      "name": "True Grit",
+      "tvdb_id": 44264
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000313",
+      "tvdb_id": 1229,
+      "name": "Jeff Bridges"
+    }
+  ]
+}

--- a/puzzles/2023-12-13.json
+++ b/puzzles/2023-12-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 134,
+  "target_tvdb_id": 3895,
+  "source_imdb_id": "nm0004937",
+  "target_imdb_id": "nm0000323",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    }
+  ]
+}

--- a/puzzles/2023-12-14.json
+++ b/puzzles/2023-12-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17276,
+  "target_tvdb_id": 1269,
+  "source_imdb_id": "nm0124930",
+  "target_imdb_id": "nm0000126",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0124930",
+      "tvdb_id": 17276,
+      "name": "Gerard Butler"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2302755",
+      "votes": 282685,
+      "rating": 6.5,
+      "name": "Olympus Has Fallen",
+      "tvdb_id": 117263
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0102798",
+      "votes": 199967,
+      "rating": 6.9,
+      "name": "Robin Hood: Prince of Thieves",
+      "tvdb_id": 8367
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000126",
+      "tvdb_id": 1269,
+      "name": "Kevin Costner"
+    }
+  ]
+}

--- a/puzzles/2023-12-15.json
+++ b/puzzles/2023-12-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2176,
+  "target_tvdb_id": 3490,
+  "source_imdb_id": "nm0000169",
+  "target_imdb_id": "nm0004778",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0477348",
+      "votes": 997439,
+      "rating": 8.2,
+      "name": "No Country for Old Men",
+      "tvdb_id": 6977
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000437",
+      "tvdb_id": 57755,
+      "name": "Woody Harrelson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120863",
+      "votes": 192304,
+      "rating": 7.6,
+      "name": "The Thin Red Line",
+      "tvdb_id": 8741
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004778",
+      "tvdb_id": 3490,
+      "name": "Adrien Brody"
+    }
+  ]
+}

--- a/puzzles/2023-12-16.json
+++ b/puzzles/2023-12-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4173,
+  "target_tvdb_id": 3392,
+  "source_imdb_id": "nm0000164",
+  "target_imdb_id": "nm0000140",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000164",
+      "tvdb_id": 4173,
+      "name": "Anthony Hopkins"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0289765",
+      "votes": 280472,
+      "rating": 7.2,
+      "name": "Red Dragon",
+      "tvdb_id": 9533
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0219324",
+      "tvdb_id": 154954,
+      "name": "Elizabeth Dennehy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119174",
+      "votes": 407687,
+      "rating": 7.7,
+      "name": "The Game",
+      "tvdb_id": 2649
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
+    }
+  ]
+}

--- a/puzzles/2023-12-17.json
+++ b/puzzles/2023-12-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 204,
+  "target_tvdb_id": 71580,
+  "source_imdb_id": "nm0000701",
+  "target_imdb_id": "nm1212722",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338013",
+      "votes": 1027917,
+      "rating": 8.3,
+      "name": "Eternal Sunshine of the Spotless Mind",
+      "tvdb_id": 38
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3501632",
+      "votes": 771855,
+      "rating": 7.9,
+      "name": "Thor: Ragnarok",
+      "tvdb_id": 284053
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1212722",
+      "tvdb_id": 71580,
+      "name": "Benedict Cumberbatch"
+    }
+  ]
+}

--- a/puzzles/2023-12-18.json
+++ b/puzzles/2023-12-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 287,
+  "target_tvdb_id": 2888,
+  "source_imdb_id": "nm0000093",
+  "target_imdb_id": "nm0000226",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2935510",
+      "votes": 244986,
+      "rating": 6.5,
+      "name": "Ad Astra",
+      "tvdb_id": 419704
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119654",
+      "votes": 582276,
+      "rating": 7.3,
+      "name": "Men in Black",
+      "tvdb_id": 607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000226",
+      "tvdb_id": 2888,
+      "name": "Will Smith"
+    }
+  ]
+}

--- a/puzzles/2023-12-19.json
+++ b/puzzles/2023-12-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 131,
+  "target_tvdb_id": 287,
+  "source_imdb_id": "nm0350453",
+  "target_imdb_id": "nm0000093",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0350453",
+      "tvdb_id": 131,
+      "name": "Jake Gyllenhaal"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2316411",
+      "votes": 200995,
+      "rating": 6.9,
+      "name": "Enemy",
+      "tvdb_id": 181886
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0491259",
+      "tvdb_id": 19119,
+      "name": "M\u00e9lanie Laurent"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    }
+  ]
+}

--- a/puzzles/2023-12-20.json
+++ b/puzzles/2023-12-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 21007,
+  "target_tvdb_id": 5081,
+  "source_imdb_id": "nm1706767",
+  "target_imdb_id": "nm1289434",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0993846",
+      "votes": 1455112,
+      "rating": 8.2,
+      "name": "The Wolf of Wall Street",
+      "tvdb_id": 106646
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1256532",
+      "tvdb_id": 19498,
+      "name": "Jon Bernthal"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3397884",
+      "votes": 444153,
+      "rating": 7.6,
+      "name": "Sicario",
+      "tvdb_id": 273481
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1289434",
+      "tvdb_id": 5081,
+      "name": "Emily Blunt"
+    }
+  ]
+}

--- a/puzzles/2023-12-21.json
+++ b/puzzles/2023-12-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2231,
+  "target_tvdb_id": 2227,
+  "source_imdb_id": "nm0000168",
+  "target_imdb_id": "nm0000173",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0121766",
+      "votes": 808568,
+      "rating": 7.6,
+      "name": "Star Wars: Episode III - Revenge of the Sith",
+      "tvdb_id": 1895
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0203009",
+      "votes": 290703,
+      "rating": 7.6,
+      "name": "Moulin Rouge!",
+      "tvdb_id": 824
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000173",
+      "tvdb_id": 2227,
+      "name": "Nicole Kidman"
+    }
+  ]
+}

--- a/puzzles/2023-12-22.json
+++ b/puzzles/2023-12-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5469,
+  "target_tvdb_id": 2228,
+  "source_imdb_id": "nm0000146",
+  "target_imdb_id": "nm0000576",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000146",
+      "tvdb_id": 5469,
+      "name": "Ralph Fiennes"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0387131",
+      "votes": 144863,
+      "rating": 7.4,
+      "name": "The Constant Gardener",
+      "tvdb_id": 1985
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0396812",
+      "tvdb_id": 6413,
+      "name": "Danny Huston"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0315733",
+      "votes": 240834,
+      "rating": 7.6,
+      "name": "21 Grams",
+      "tvdb_id": 470
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000576",
+      "tvdb_id": 2228,
+      "name": "Sean Penn"
+    }
+  ]
+}

--- a/puzzles/2023-12-23.json
+++ b/puzzles/2023-12-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1038,
+  "target_tvdb_id": 18999,
+  "source_imdb_id": "nm0000149",
+  "target_imdb_id": "nm0799777",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000149",
+      "tvdb_id": 1038,
+      "name": "Jodie Foster"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0454848",
+      "votes": 382377,
+      "rating": 7.6,
+      "name": "Inside Man",
+      "tvdb_id": 388
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    }
+  ]
+}

--- a/puzzles/2023-12-24.json
+++ b/puzzles/2023-12-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1813,
+  "target_tvdb_id": 12052,
+  "source_imdb_id": "nm0004266",
+  "target_imdb_id": "nm0000569",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004266",
+      "tvdb_id": 1813,
+      "name": "Anne Hathaway"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1345836",
+      "votes": 1735537,
+      "rating": 8.4,
+      "name": "The Dark Knight Rises",
+      "tvdb_id": 49026
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114369",
+      "votes": 1690351,
+      "rating": 8.6,
+      "name": "Se7en",
+      "tvdb_id": 807
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000569",
+      "tvdb_id": 12052,
+      "name": "Gwyneth Paltrow"
+    }
+  ]
+}

--- a/puzzles/2023-12-25.json
+++ b/puzzles/2023-12-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1136406,
+  "target_tvdb_id": 16483,
+  "source_imdb_id": "nm4043618",
+  "target_imdb_id": "nm0000230",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm4043618",
+      "tvdb_id": 1136406,
+      "name": "Tom Holland"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1464335",
+      "votes": 225461,
+      "rating": 6.3,
+      "name": "Uncharted",
+      "tvdb_id": 335787
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000104",
+      "tvdb_id": 3131,
+      "name": "Antonio Banderas"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0112401",
+      "votes": 85563,
+      "rating": 6.3,
+      "name": "Assassins",
+      "tvdb_id": 9691
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000230",
+      "tvdb_id": 16483,
+      "name": "Sylvester Stallone"
+    }
+  ]
+}

--- a/puzzles/2023-12-26.json
+++ b/puzzles/2023-12-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 116,
+  "target_tvdb_id": 5081,
+  "source_imdb_id": "nm0461136",
+  "target_imdb_id": "nm1289434",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0461136",
+      "tvdb_id": 116,
+      "name": "Keira Knightley"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0325980",
+      "votes": 1149544,
+      "rating": 8.1,
+      "name": "Pirates of the Caribbean: The Curse of the Black Pearl",
+      "tvdb_id": 22
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000136",
+      "tvdb_id": 85,
+      "name": "Johnny Depp"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2180411",
+      "votes": 144042,
+      "rating": 5.9,
+      "name": "Into the Woods",
+      "tvdb_id": 224141
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1289434",
+      "tvdb_id": 5081,
+      "name": "Emily Blunt"
+    }
+  ]
+}

--- a/puzzles/2023-12-27.json
+++ b/puzzles/2023-12-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 23532,
+  "target_tvdb_id": 1367,
+  "source_imdb_id": "nm0000867",
+  "target_imdb_id": "nm0397102",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000867",
+      "tvdb_id": 23532,
+      "name": "Jason Bateman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0431197",
+      "votes": 128174,
+      "rating": 7.0,
+      "name": "The Kingdom",
+      "tvdb_id": 4349
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1019674",
+      "tvdb_id": 1366,
+      "name": "Sala Baker"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120737",
+      "votes": 1909585,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Fellowship of the Ring",
+      "tvdb_id": 120
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0397102",
+      "tvdb_id": 1367,
+      "name": "Alan Howard"
+    }
+  ]
+}

--- a/puzzles/2023-12-28.json
+++ b/puzzles/2023-12-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5292,
+  "target_tvdb_id": 1003,
+  "source_imdb_id": "nm0000243",
+  "target_imdb_id": "nm0000606",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000243",
+      "tvdb_id": 5292,
+      "name": "Denzel Washington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1037705",
+      "votes": 325917,
+      "rating": 6.8,
+      "name": "The Book of Eli",
+      "tvdb_id": 20504
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000198",
+      "tvdb_id": 64,
+      "name": "Gary Oldman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110413",
+      "votes": 1184637,
+      "rating": 8.5,
+      "name": "L\u00e9on: The Professional",
+      "tvdb_id": 101
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000606",
+      "tvdb_id": 1003,
+      "name": "Jean Reno"
+    }
+  ]
+}

--- a/puzzles/2023-12-29.json
+++ b/puzzles/2023-12-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 9642,
+  "target_tvdb_id": 4491,
+  "source_imdb_id": "nm0000179",
+  "target_imdb_id": "nm0000098",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000179",
+      "tvdb_id": 9642,
+      "name": "Jude Law"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0339291",
+      "votes": 213826,
+      "rating": 6.8,
+      "name": "A Series of Unfortunate Events",
+      "tvdb_id": 11774
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000120",
+      "tvdb_id": 206,
+      "name": "Jim Carrey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0315327",
+      "votes": 414438,
+      "rating": 6.8,
+      "name": "Bruce Almighty",
+      "tvdb_id": 310
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000098",
+      "tvdb_id": 4491,
+      "name": "Jennifer Aniston"
+    }
+  ]
+}

--- a/puzzles/2023-12-30.json
+++ b/puzzles/2023-12-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 569,
+  "target_tvdb_id": 368,
+  "source_imdb_id": "nm0000160",
+  "target_imdb_id": "nm0000702",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000160",
+      "tvdb_id": 569,
+      "name": "Ethan Hawke"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt11138512",
+      "votes": 225973,
+      "rating": 7.0,
+      "name": "The Northman",
+      "tvdb_id": 639933
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0144084",
+      "votes": 651517,
+      "rating": 7.6,
+      "name": "American Psycho",
+      "tvdb_id": 1359
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000702",
+      "tvdb_id": 368,
+      "name": "Reese Witherspoon"
+    }
+  ]
+}

--- a/puzzles/2023-12-31.json
+++ b/puzzles/2023-12-31.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4173,
+  "target_tvdb_id": 585902,
+  "source_imdb_id": "nm0000164",
+  "target_imdb_id": "nm0032370",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000164",
+      "tvdb_id": 4173,
+      "name": "Anthony Hopkins"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3501632",
+      "votes": 771855,
+      "rating": 7.9,
+      "name": "Thor: Ragnarok",
+      "tvdb_id": 284053
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0167260",
+      "votes": 1880701,
+      "rating": 9.0,
+      "name": "The Lord of the Rings: The Return of the King",
+      "tvdb_id": 122
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0032370",
+      "tvdb_id": 585902,
+      "name": "Noel Appleby"
+    }
+  ]
+}

--- a/puzzles/2024-01-01.json
+++ b/puzzles/2024-01-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3087,
+  "target_tvdb_id": 2461,
+  "source_imdb_id": "nm0000380",
+  "target_imdb_id": "nm0000154",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000380",
+      "tvdb_id": 3087,
+      "name": "Robert Duvall"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0078788",
+      "votes": 680101,
+      "rating": 8.5,
+      "name": "Apocalypse Now",
+      "tvdb_id": 28
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2333784",
+      "votes": 187193,
+      "rating": 6.1,
+      "name": "The Expendables 3",
+      "tvdb_id": 138103
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000154",
+      "tvdb_id": 2461,
+      "name": "Mel Gibson"
+    }
+  ]
+}

--- a/puzzles/2024-01-02.json
+++ b/puzzles/2024-01-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2524,
+  "target_tvdb_id": 204,
+  "source_imdb_id": "nm0362766",
+  "target_imdb_id": "nm0000701",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0362766",
+      "tvdb_id": 2524,
+      "name": "Tom Hardy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120338",
+      "votes": 1215558,
+      "rating": 7.9,
+      "name": "Titanic",
+      "tvdb_id": 597
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
+    }
+  ]
+}

--- a/puzzles/2024-01-03.json
+++ b/puzzles/2024-01-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2461,
+  "target_tvdb_id": 31,
+  "source_imdb_id": "nm0000154",
+  "target_imdb_id": "nm0000158",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000154",
+      "tvdb_id": 2461,
+      "name": "Mel Gibson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0277434",
+      "votes": 146036,
+      "rating": 7.1,
+      "name": "We Were Soldiers",
+      "tvdb_id": 10590
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001608",
+      "tvdb_id": 12834,
+      "name": "Barry Pepper"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120815",
+      "votes": 1418419,
+      "rating": 8.6,
+      "name": "Saving Private Ryan",
+      "tvdb_id": 857
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
+    }
+  ]
+}

--- a/puzzles/2024-01-04.json
+++ b/puzzles/2024-01-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5469,
+  "target_tvdb_id": 8691,
+  "source_imdb_id": "nm0000146",
+  "target_imdb_id": "nm0757855",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000146",
+      "tvdb_id": 5469,
+      "name": "Ralph Fiennes"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0800320",
+      "votes": 286593,
+      "rating": 5.8,
+      "name": "Clash of the Titans",
+      "tvdb_id": 18823
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0499549",
+      "votes": 1338763,
+      "rating": 7.9,
+      "name": "Avatar",
+      "tvdb_id": 19995
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    }
+  ]
+}

--- a/puzzles/2024-01-05.json
+++ b/puzzles/2024-01-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 51329,
+  "target_tvdb_id": 1333,
+  "source_imdb_id": "nm0177896",
+  "target_imdb_id": "nm0785227",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1800241",
+      "votes": 487634,
+      "rating": 7.2,
+      "name": "American Hustle",
+      "tvdb_id": 168672
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0482571",
+      "votes": 1359502,
+      "rating": 8.5,
+      "name": "The Prestige",
+      "tvdb_id": 1124
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0785227",
+      "tvdb_id": 1333,
+      "name": "Andy Serkis"
+    }
+  ]
+}

--- a/puzzles/2024-01-06.json
+++ b/puzzles/2024-01-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2888,
+  "target_tvdb_id": 12898,
+  "source_imdb_id": "nm0000226",
+  "target_imdb_id": "nm0000741",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000226",
+      "tvdb_id": 2888,
+      "name": "Will Smith"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119654",
+      "votes": 582276,
+      "rating": 7.3,
+      "name": "Men in Black",
+      "tvdb_id": 607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001724",
+      "tvdb_id": 4252,
+      "name": "Tony Shalhoub"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0177789",
+      "votes": 168793,
+      "rating": 7.4,
+      "name": "Galaxy Quest",
+      "tvdb_id": 926
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000741",
+      "tvdb_id": 12898,
+      "name": "Tim Allen"
+    }
+  ]
+}

--- a/puzzles/2024-01-07.json
+++ b/puzzles/2024-01-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2963,
+  "target_tvdb_id": 1461,
+  "source_imdb_id": "nm0000115",
+  "target_imdb_id": "nm0000123",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000115",
+      "tvdb_id": 2963,
+      "name": "Nicolas Cage"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0117500",
+      "votes": 345978,
+      "rating": 7.4,
+      "name": "The Rock",
+      "tvdb_id": 9802
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000438",
+      "tvdb_id": 228,
+      "name": "Ed Harris"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1454468",
+      "votes": 838982,
+      "rating": 7.7,
+      "name": "Gravity",
+      "tvdb_id": 49047
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    }
+  ]
+}

--- a/puzzles/2024-01-08.json
+++ b/puzzles/2024-01-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6384,
+  "target_tvdb_id": 1327,
+  "source_imdb_id": "nm0000206",
+  "target_imdb_id": "nm0005212",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000206",
+      "tvdb_id": 6384,
+      "name": "Keanu Reeves"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0133093",
+      "votes": 1950577,
+      "rating": 8.7,
+      "name": "The Matrix",
+      "tvdb_id": 603
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915989",
+      "tvdb_id": 1331,
+      "name": "Hugo Weaving"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0903624",
+      "votes": 842123,
+      "rating": 7.8,
+      "name": "The Hobbit: An Unexpected Journey",
+      "tvdb_id": 49051
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005212",
+      "tvdb_id": 1327,
+      "name": "Ian McKellen"
+    }
+  ]
+}

--- a/puzzles/2024-01-09.json
+++ b/puzzles/2024-01-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 18999,
+  "target_tvdb_id": 887,
+  "source_imdb_id": "nm0799777",
+  "target_imdb_id": "nm0005562",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2278388",
+      "votes": 834412,
+      "rating": 8.1,
+      "name": "The Grand Budapest Hotel",
+      "tvdb_id": 120467
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005562",
+      "tvdb_id": 887,
+      "name": "Owen Wilson"
+    }
+  ]
+}

--- a/puzzles/2024-01-10.json
+++ b/puzzles/2024-01-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 7399,
+  "target_tvdb_id": 73421,
+  "source_imdb_id": "nm0001774",
+  "target_imdb_id": "nm0001618",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001774",
+      "tvdb_id": 7399,
+      "name": "Ben Stiller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0359950",
+      "votes": 325658,
+      "rating": 7.3,
+      "name": "The Secret Life of Walter Mitty",
+      "tvdb_id": 116745
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1325419",
+      "tvdb_id": 41091,
+      "name": "Kristen Wiig"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1798709",
+      "votes": 632987,
+      "rating": 8.0,
+      "name": "Her",
+      "tvdb_id": 152601
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001618",
+      "tvdb_id": 73421,
+      "name": "Joaquin Phoenix"
+    }
+  ]
+}

--- a/puzzles/2024-01-11.json
+++ b/puzzles/2024-01-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 934,
+  "target_tvdb_id": 48,
+  "source_imdb_id": "nm0000128",
+  "target_imdb_id": "nm0000293",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0955308",
+      "votes": 274713,
+      "rating": 6.6,
+      "name": "Robin Hood",
+      "tvdb_id": 20662
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0167260",
+      "votes": 1880701,
+      "rating": 9.0,
+      "name": "The Lord of the Rings: The Return of the King",
+      "tvdb_id": 122
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000293",
+      "tvdb_id": 48,
+      "name": "Sean Bean"
+    }
+  ]
+}

--- a/puzzles/2024-01-12.json
+++ b/puzzles/2024-01-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 12898,
+  "target_tvdb_id": 569,
+  "source_imdb_id": "nm0000741",
+  "target_imdb_id": "nm0000160",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000741",
+      "tvdb_id": 12898,
+      "name": "Tim Allen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0177789",
+      "votes": 168793,
+      "rating": 7.4,
+      "name": "Galaxy Quest",
+      "tvdb_id": 926
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001724",
+      "tvdb_id": 4252,
+      "name": "Tony Shalhoub"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119177",
+      "votes": 311282,
+      "rating": 7.8,
+      "name": "Gattaca",
+      "tvdb_id": 782
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000160",
+      "tvdb_id": 569,
+      "name": "Ethan Hawke"
+    }
+  ]
+}

--- a/puzzles/2024-01-13.json
+++ b/puzzles/2024-01-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 114,
+  "target_tvdb_id": 1038,
+  "source_imdb_id": "nm0089217",
+  "target_imdb_id": "nm0000149",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0089217",
+      "tvdb_id": 114,
+      "name": "Orlando Bloom"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0167260",
+      "votes": 1880701,
+      "rating": 9.0,
+      "name": "The Lord of the Rings: The Return of the King",
+      "tvdb_id": 122
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000293",
+      "tvdb_id": 48,
+      "name": "Sean Bean"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0408790",
+      "votes": 166149,
+      "rating": 6.3,
+      "name": "Flightplan",
+      "tvdb_id": 9315
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000149",
+      "tvdb_id": 1038,
+      "name": "Jodie Foster"
+    }
+  ]
+}

--- a/puzzles/2024-01-14.json
+++ b/puzzles/2024-01-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 23532,
+  "target_tvdb_id": 1331,
+  "source_imdb_id": "nm0000867",
+  "target_imdb_id": "nm0915989",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000867",
+      "tvdb_id": 23532,
+      "name": "Jason Bateman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0448157",
+      "votes": 493621,
+      "rating": 6.4,
+      "name": "Hancock",
+      "tvdb_id": 8960
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0550371",
+      "tvdb_id": 1665,
+      "name": "Eddie Marsan"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0434409",
+      "votes": 1138043,
+      "rating": 8.2,
+      "name": "V for Vendetta",
+      "tvdb_id": 752
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915989",
+      "tvdb_id": 1331,
+      "name": "Hugo Weaving"
+    }
+  ]
+}

--- a/puzzles/2024-01-15.json
+++ b/puzzles/2024-01-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 504,
+  "target_tvdb_id": 2227,
+  "source_imdb_id": "nm0000209",
+  "target_imdb_id": "nm0000173",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000209",
+      "tvdb_id": 504,
+      "name": "Tim Robbins"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0407304",
+      "votes": 458497,
+      "rating": 6.5,
+      "name": "War of the Worlds",
+      "tvdb_id": 74
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000129",
+      "tvdb_id": 500,
+      "name": "Tom Cruise"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120663",
+      "votes": 353030,
+      "rating": 7.5,
+      "name": "Eyes Wide Shut",
+      "tvdb_id": 345
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000173",
+      "tvdb_id": 2227,
+      "name": "Nicole Kidman"
+    }
+  ]
+}

--- a/puzzles/2024-01-16.json
+++ b/puzzles/2024-01-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 11108,
+  "target_tvdb_id": 118,
+  "source_imdb_id": "nm0670408",
+  "target_imdb_id": "nm0001691",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0670408",
+      "tvdb_id": 11108,
+      "name": "Simon Pegg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0425112",
+      "votes": 515671,
+      "rating": 7.8,
+      "name": "Hot Fuzz",
+      "tvdb_id": 4638
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0631490",
+      "tvdb_id": 2440,
+      "name": "Bill Nighy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0449088",
+      "votes": 664879,
+      "rating": 7.1,
+      "name": "Pirates of the Caribbean: At World's End",
+      "tvdb_id": 285
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001691",
+      "tvdb_id": 118,
+      "name": "Geoffrey Rush"
+    }
+  ]
+}

--- a/puzzles/2024-01-17.json
+++ b/puzzles/2024-01-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 206,
+  "target_tvdb_id": 1269,
+  "source_imdb_id": "nm0000120",
+  "target_imdb_id": "nm0000126",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000120",
+      "tvdb_id": 206,
+      "name": "Jim Carrey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0315327",
+      "votes": 414438,
+      "rating": 6.8,
+      "name": "Bruce Almighty",
+      "tvdb_id": 310
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0102798",
+      "votes": 199967,
+      "rating": 6.9,
+      "name": "Robin Hood: Prince of Thieves",
+      "tvdb_id": 8367
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000126",
+      "tvdb_id": 1269,
+      "name": "Kevin Costner"
+    }
+  ]
+}

--- a/puzzles/2024-01-18.json
+++ b/puzzles/2024-01-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1269,
+  "target_tvdb_id": 1158,
+  "source_imdb_id": "nm0000126",
+  "target_imdb_id": "nm0000199",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000126",
+      "tvdb_id": 1269,
+      "name": "Kevin Costner"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0094226",
+      "votes": 317787,
+      "rating": 7.8,
+      "name": "The Untouchables",
+      "tvdb_id": 117
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0071562",
+      "votes": 1296165,
+      "rating": 9.0,
+      "name": "The Godfather Part II",
+      "tvdb_id": 240
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    }
+  ]
+}

--- a/puzzles/2024-01-19.json
+++ b/puzzles/2024-01-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17288,
+  "target_tvdb_id": 4173,
+  "source_imdb_id": "nm1055413",
+  "target_imdb_id": "nm0000164",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119643",
+      "votes": 251071,
+      "rating": 7.2,
+      "name": "Meet Joe Black",
+      "tvdb_id": 297
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000164",
+      "tvdb_id": 4173,
+      "name": "Anthony Hopkins"
+    }
+  ]
+}

--- a/puzzles/2024-01-20.json
+++ b/puzzles/2024-01-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 51329,
+  "target_tvdb_id": 3087,
+  "source_imdb_id": "nm0177896",
+  "target_imdb_id": "nm0000380",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1045658",
+      "votes": 720058,
+      "rating": 7.7,
+      "name": "Silver Linings Playbook",
+      "tvdb_id": 82693
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0071562",
+      "votes": 1296165,
+      "rating": 9.0,
+      "name": "The Godfather Part II",
+      "tvdb_id": 240
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000380",
+      "tvdb_id": 3087,
+      "name": "Robert Duvall"
+    }
+  ]
+}

--- a/puzzles/2024-01-21.json
+++ b/puzzles/2024-01-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 112,
+  "target_tvdb_id": 13,
+  "source_imdb_id": "nm0000949",
+  "target_imdb_id": "nm0000983",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000949",
+      "tvdb_id": 112,
+      "name": "Cate Blanchett"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338751",
+      "votes": 370181,
+      "rating": 7.5,
+      "name": "The Aviator",
+      "tvdb_id": 2567
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0266543",
+      "votes": 1062914,
+      "rating": 8.2,
+      "name": "Finding Nemo",
+      "tvdb_id": 12
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000983",
+      "tvdb_id": 13,
+      "name": "Albert Brooks"
+    }
+  ]
+}

--- a/puzzles/2024-01-22.json
+++ b/puzzles/2024-01-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2440,
+  "target_tvdb_id": 4495,
+  "source_imdb_id": "nm0631490",
+  "target_imdb_id": "nm0136797",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0631490",
+      "tvdb_id": 2440,
+      "name": "Bill Nighy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0383574",
+      "votes": 734303,
+      "rating": 7.3,
+      "name": "Pirates of the Caribbean: Dead Man's Chest",
+      "tvdb_id": 58
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0461136",
+      "tvdb_id": 116,
+      "name": "Keira Knightley"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1307068",
+      "votes": 116625,
+      "rating": 6.7,
+      "name": "Seeking a Friend for the End of the World",
+      "tvdb_id": 88005
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0136797",
+      "tvdb_id": 4495,
+      "name": "Steve Carell"
+    }
+  ]
+}

--- a/puzzles/2024-01-23.json
+++ b/puzzles/2024-01-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1230,
+  "target_tvdb_id": 3036,
+  "source_imdb_id": "nm0000422",
+  "target_imdb_id": "nm0000131",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000422",
+      "tvdb_id": 1230,
+      "name": "John Goodman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0198781",
+      "votes": 928601,
+      "rating": 8.1,
+      "name": "Monsters, Inc.",
+      "tvdb_id": 585
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000345",
+      "tvdb_id": 7904,
+      "name": "Billy Crystal"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0265029",
+      "votes": 58898,
+      "rating": 5.7,
+      "name": "America's Sweethearts",
+      "tvdb_id": 11467
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000131",
+      "tvdb_id": 3036,
+      "name": "John Cusack"
+    }
+  ]
+}

--- a/puzzles/2024-01-24.json
+++ b/puzzles/2024-01-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 449,
+  "target_tvdb_id": 13240,
+  "source_imdb_id": "nm0059431",
+  "target_imdb_id": "nm0000242",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0892769",
+      "votes": 758216,
+      "rating": 8.1,
+      "name": "How to Train Your Dragon",
+      "tvdb_id": 10191
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm2554352",
+      "tvdb_id": 51990,
+      "name": "T.J. Miller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2109248",
+      "votes": 319961,
+      "rating": 5.6,
+      "name": "Transformers: Age of Extinction",
+      "tvdb_id": 91314
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
+    }
+  ]
+}

--- a/puzzles/2024-01-25.json
+++ b/puzzles/2024-01-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 173431,
+  "target_tvdb_id": 6885,
+  "source_imdb_id": "nm0021600",
+  "target_imdb_id": "nm0000234",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0021600",
+      "tvdb_id": 173431,
+      "name": "Bruce Allpress"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0167261",
+      "votes": 1697780,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Two Towers",
+      "tvdb_id": 121
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001557",
+      "tvdb_id": 110,
+      "name": "Viggo Mortensen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0898367",
+      "votes": 244967,
+      "rating": 7.2,
+      "name": "The Road",
+      "tvdb_id": 20766
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000234",
+      "tvdb_id": 6885,
+      "name": "Charlize Theron"
+    }
+  ]
+}

--- a/puzzles/2024-01-26.json
+++ b/puzzles/2024-01-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 887,
+  "target_tvdb_id": 2524,
+  "source_imdb_id": "nm0005562",
+  "target_imdb_id": "nm0362766",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005562",
+      "tvdb_id": 887,
+      "name": "Owen Wilson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1605783",
+      "votes": 433605,
+      "rating": 7.7,
+      "name": "Midnight in Paris",
+      "tvdb_id": 59436
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0182839",
+      "tvdb_id": 8293,
+      "name": "Marion Cotillard"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1345836",
+      "votes": 1735537,
+      "rating": 8.4,
+      "name": "The Dark Knight Rises",
+      "tvdb_id": 49026
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0362766",
+      "tvdb_id": 2524,
+      "name": "Tom Hardy"
+    }
+  ]
+}

--- a/puzzles/2024-01-27.json
+++ b/puzzles/2024-01-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 65731,
+  "target_tvdb_id": 2232,
+  "source_imdb_id": "nm0941777",
+  "target_imdb_id": "nm0000474",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0941777",
+      "tvdb_id": 65731,
+      "name": "Sam Worthington"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0499549",
+      "votes": 1338763,
+      "rating": 7.9,
+      "name": "Avatar",
+      "tvdb_id": 19995
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm4798882",
+      "tvdb_id": null,
+      "name": "Brad Jacobowitz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2562232",
+      "votes": 643891,
+      "rating": 7.7,
+      "name": "Birdman or (The Unexpected Virtue of Ignorance)",
+      "tvdb_id": 194662
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000474",
+      "tvdb_id": 2232,
+      "name": "Michael Keaton"
+    }
+  ]
+}

--- a/puzzles/2024-01-28.json
+++ b/puzzles/2024-01-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 10959,
+  "target_tvdb_id": 22226,
+  "source_imdb_id": "nm0479471",
+  "target_imdb_id": "nm0748620",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0479471",
+      "tvdb_id": 10959,
+      "name": "Shia LaBeouf"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2713180",
+      "votes": 509519,
+      "rating": 7.5,
+      "name": "Fury",
+      "tvdb_id": 228150
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0671567",
+      "tvdb_id": 454,
+      "name": "Michael Pe\u00f1a"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0478970",
+      "votes": 689185,
+      "rating": 7.3,
+      "name": "Ant-Man",
+      "tvdb_id": 102899
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
+    }
+  ]
+}

--- a/puzzles/2024-01-29.json
+++ b/puzzles/2024-01-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 18269,
+  "target_tvdb_id": 976,
+  "source_imdb_id": "nm0000409",
+  "target_imdb_id": "nm0005458",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000409",
+      "tvdb_id": 18269,
+      "name": "Brendan Fraser"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0859163",
+      "votes": 165439,
+      "rating": 5.2,
+      "name": "The Mummy: Tomb of the Dragon Emperor",
+      "tvdb_id": 1735
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001472",
+      "tvdb_id": 1336,
+      "name": "Jet Li"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1320253",
+      "votes": 352287,
+      "rating": 6.4,
+      "name": "The Expendables",
+      "tvdb_id": 27578
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005458",
+      "tvdb_id": 976,
+      "name": "Jason Statham"
+    }
+  ]
+}

--- a/puzzles/2024-01-30.json
+++ b/puzzles/2024-01-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3894,
+  "target_tvdb_id": 4756,
+  "source_imdb_id": "nm0000288",
+  "target_imdb_id": "nm0000111",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0097441",
+      "votes": 138396,
+      "rating": 7.8,
+      "name": "Glory",
+      "tvdb_id": 9665
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000111",
+      "tvdb_id": 4756,
+      "name": "Matthew Broderick"
+    }
+  ]
+}

--- a/puzzles/2024-01-31.json
+++ b/puzzles/2024-01-31.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 996701,
+  "target_tvdb_id": 62,
+  "source_imdb_id": "nm1886602",
+  "target_imdb_id": "nm0000246",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1886602",
+      "tvdb_id": 996701,
+      "name": "Miles Teller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2582802",
+      "votes": 898359,
+      "rating": 8.5,
+      "name": "Whiplash",
+      "tvdb_id": 244786
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119395",
+      "votes": 120278,
+      "rating": 6.4,
+      "name": "The Jackal",
+      "tvdb_id": 4824
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000246",
+      "tvdb_id": 62,
+      "name": "Bruce Willis"
+    }
+  ]
+}

--- a/puzzles/2024-02-01.json
+++ b/puzzles/2024-02-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17604,
+  "target_tvdb_id": 1532,
+  "source_imdb_id": "nm0719637",
+  "target_imdb_id": "nm0000195",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0719637",
+      "tvdb_id": 17604,
+      "name": "Jeremy Renner"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0848228",
+      "votes": 1411541,
+      "rating": 8.0,
+      "name": "The Avengers",
+      "tvdb_id": 24428
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0424060",
+      "tvdb_id": 1245,
+      "name": "Scarlett Johansson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0335266",
+      "votes": 465972,
+      "rating": 7.7,
+      "name": "Lost in Translation",
+      "tvdb_id": 153
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000195",
+      "tvdb_id": 1532,
+      "name": "Bill Murray"
+    }
+  ]
+}

--- a/puzzles/2024-02-02.json
+++ b/puzzles/2024-02-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3392,
+  "target_tvdb_id": 1461,
+  "source_imdb_id": "nm0000140",
+  "target_imdb_id": "nm0000123",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0478970",
+      "votes": 689185,
+      "rating": 7.3,
+      "name": "Ant-Man",
+      "tvdb_id": 102899
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0339460",
+      "tvdb_id": 20750,
+      "name": "Judy Greer"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1964418",
+      "votes": 185810,
+      "rating": 6.4,
+      "name": "Tomorrowland",
+      "tvdb_id": 158852
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    }
+  ]
+}

--- a/puzzles/2024-02-03.json
+++ b/puzzles/2024-02-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4517,
+  "target_tvdb_id": 17288,
+  "source_imdb_id": "nm0000582",
+  "target_imdb_id": "nm1055413",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000582",
+      "tvdb_id": 4517,
+      "name": "Joe Pesci"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1302006",
+      "votes": 401561,
+      "rating": 7.8,
+      "name": "The Irishman",
+      "tvdb_id": 398978
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001593",
+      "tvdb_id": 10690,
+      "name": "Anna Paquin"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1877832",
+      "votes": 723350,
+      "rating": 7.9,
+      "name": "X-Men: Days of Future Past",
+      "tvdb_id": 127585
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
+    }
+  ]
+}

--- a/puzzles/2024-02-04.json
+++ b/puzzles/2024-02-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 31,
+  "target_tvdb_id": 4173,
+  "source_imdb_id": "nm0000158",
+  "target_imdb_id": "nm0000164",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000158",
+      "tvdb_id": 31,
+      "name": "Tom Hanks"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0109830",
+      "votes": 2127602,
+      "rating": 8.8,
+      "name": "Forrest Gump",
+      "tvdb_id": 13
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000705",
+      "tvdb_id": 32,
+      "name": "Robin Wright"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0442933",
+      "votes": 170595,
+      "rating": 6.3,
+      "name": "Beowulf",
+      "tvdb_id": 2310
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000164",
+      "tvdb_id": 4173,
+      "name": "Anthony Hopkins"
+    }
+  ]
+}

--- a/puzzles/2024-02-05.json
+++ b/puzzles/2024-02-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 12073,
+  "target_tvdb_id": 3129,
+  "source_imdb_id": "nm0000196",
+  "target_imdb_id": "nm0000619",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000196",
+      "tvdb_id": 12073,
+      "name": "Mike Myers"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000619",
+      "tvdb_id": 3129,
+      "name": "Tim Roth"
+    }
+  ]
+}

--- a/puzzles/2024-02-06.json
+++ b/puzzles/2024-02-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 13240,
+  "target_tvdb_id": 73968,
+  "source_imdb_id": "nm0000242",
+  "target_imdb_id": "nm0147147",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000242",
+      "tvdb_id": 13240,
+      "name": "Mark Wahlberg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0964517",
+      "votes": 376098,
+      "rating": 7.8,
+      "name": "The Fighter",
+      "tvdb_id": 45317
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0770828",
+      "votes": 784138,
+      "rating": 7.1,
+      "name": "Man of Steel",
+      "tvdb_id": 49521
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
+    }
+  ]
+}

--- a/puzzles/2024-02-07.json
+++ b/puzzles/2024-02-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 85,
+  "target_tvdb_id": 103,
+  "source_imdb_id": "nm0000136",
+  "target_imdb_id": "nm0749263",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000136",
+      "tvdb_id": 85,
+      "name": "Johnny Depp"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0108550",
+      "votes": 243369,
+      "rating": 7.7,
+      "name": "What's Eating Gilbert Grape",
+      "tvdb_id": 1587
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1130884",
+      "votes": 1353782,
+      "rating": 8.2,
+      "name": "Shutter Island",
+      "tvdb_id": 11324
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
+    }
+  ]
+}

--- a/puzzles/2024-02-08.json
+++ b/puzzles/2024-02-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 37625,
+  "target_tvdb_id": 27428,
+  "source_imdb_id": "nm1940449",
+  "target_imdb_id": "nm1093951",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1940449",
+      "tvdb_id": 37625,
+      "name": "Andrew Garfield"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1872181",
+      "votes": 510599,
+      "rating": 6.6,
+      "name": "The Amazing Spider-Man 2",
+      "tvdb_id": 102382
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0316079",
+      "tvdb_id": 13242,
+      "name": "Paul Giamatti"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0443543",
+      "votes": 379380,
+      "rating": 7.5,
+      "name": "The Illusionist",
+      "tvdb_id": 1491
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1093951",
+      "tvdb_id": 27428,
+      "name": "Aaron Taylor-Johnson"
+    }
+  ]
+}

--- a/puzzles/2024-02-09.json
+++ b/puzzles/2024-02-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4517,
+  "target_tvdb_id": 9642,
+  "source_imdb_id": "nm0000582",
+  "target_imdb_id": "nm0000179",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000582",
+      "tvdb_id": 4517,
+      "name": "Joe Pesci"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1302006",
+      "votes": 401561,
+      "rating": 7.8,
+      "name": "The Irishman",
+      "tvdb_id": 398978
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000172",
+      "tvdb_id": 1037,
+      "name": "Harvey Keitel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2278388",
+      "votes": 834412,
+      "rating": 8.1,
+      "name": "The Grand Budapest Hotel",
+      "tvdb_id": 120467
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000179",
+      "tvdb_id": 9642,
+      "name": "Jude Law"
+    }
+  ]
+}

--- a/puzzles/2024-02-10.json
+++ b/puzzles/2024-02-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 116,
+  "target_tvdb_id": 70851,
+  "source_imdb_id": "nm0461136",
+  "target_imdb_id": "nm0085312",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0461136",
+      "tvdb_id": 116,
+      "name": "Keira Knightley"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0366627",
+      "votes": 116214,
+      "rating": 7.1,
+      "name": "The Jacket",
+      "tvdb_id": 9667
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004778",
+      "tvdb_id": 3490,
+      "name": "Adrien Brody"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0360717",
+      "votes": 432227,
+      "rating": 7.2,
+      "name": "King Kong",
+      "tvdb_id": 254
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0085312",
+      "tvdb_id": 70851,
+      "name": "Jack Black"
+    }
+  ]
+}

--- a/puzzles/2024-02-11.json
+++ b/puzzles/2024-02-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4491,
+  "target_tvdb_id": 3061,
+  "source_imdb_id": "nm0000098",
+  "target_imdb_id": "nm0000191",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000098",
+      "tvdb_id": 4491,
+      "name": "Jennifer Aniston"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1564367",
+      "votes": 252391,
+      "rating": 6.4,
+      "name": "Just Go with It",
+      "tvdb_id": 50546
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000173",
+      "tvdb_id": 2227,
+      "name": "Nicole Kidman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0203009",
+      "votes": 290703,
+      "rating": 7.6,
+      "name": "Moulin Rouge!",
+      "tvdb_id": 824
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
+    }
+  ]
+}

--- a/puzzles/2024-02-12.json
+++ b/puzzles/2024-02-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 16851,
+  "target_tvdb_id": 7447,
+  "source_imdb_id": "nm0000982",
+  "target_imdb_id": "nm0000285",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000982",
+      "tvdb_id": 16851,
+      "name": "Josh Brolin"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1403865",
+      "votes": 346030,
+      "rating": 7.6,
+      "name": "True Grit",
+      "tvdb_id": 44264
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000285",
+      "tvdb_id": 7447,
+      "name": "Alec Baldwin"
+    }
+  ]
+}

--- a/puzzles/2024-02-13.json
+++ b/puzzles/2024-02-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 64,
+  "target_tvdb_id": 3129,
+  "source_imdb_id": "nm0000198",
+  "target_imdb_id": "nm0000619",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000198",
+      "tvdb_id": 64,
+      "name": "Gary Oldman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119116",
+      "votes": 484439,
+      "rating": 7.6,
+      "name": "The Fifth Element",
+      "tvdb_id": 18
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000246",
+      "tvdb_id": 62,
+      "name": "Bruce Willis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000619",
+      "tvdb_id": 3129,
+      "name": "Tim Roth"
+    }
+  ]
+}

--- a/puzzles/2024-02-14.json
+++ b/puzzles/2024-02-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 11108,
+  "target_tvdb_id": 2461,
+  "source_imdb_id": "nm0670408",
+  "target_imdb_id": "nm0000154",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0670408",
+      "tvdb_id": 11108,
+      "name": "Simon Pegg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2488496",
+      "votes": 944891,
+      "rating": 7.8,
+      "name": "Star Wars: Episode VII - The Force Awakens",
+      "tvdb_id": 140607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2333784",
+      "votes": 187193,
+      "rating": 6.1,
+      "name": "The Expendables 3",
+      "tvdb_id": 138103
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000154",
+      "tvdb_id": 2461,
+      "name": "Mel Gibson"
+    }
+  ]
+}

--- a/puzzles/2024-02-15.json
+++ b/puzzles/2024-02-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2963,
+  "target_tvdb_id": 12052,
+  "source_imdb_id": "nm0000115",
+  "target_imdb_id": "nm0000569",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000115",
+      "tvdb_id": 2963,
+      "name": "Nicolas Cage"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0325805",
+      "votes": 134035,
+      "rating": 7.3,
+      "name": "Matchstick Men",
+      "tvdb_id": 7270
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005377",
+      "tvdb_id": 6807,
+      "name": "Sam Rockwell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1228705",
+      "votes": 833777,
+      "rating": 6.9,
+      "name": "Iron Man 2",
+      "tvdb_id": 10138
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000569",
+      "tvdb_id": 12052,
+      "name": "Gwyneth Paltrow"
+    }
+  ]
+}

--- a/puzzles/2024-02-16.json
+++ b/puzzles/2024-02-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 24045,
+  "target_tvdb_id": 4517,
+  "source_imdb_id": "nm0330687",
+  "target_imdb_id": "nm0000582",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0458481",
+      "votes": 165569,
+      "rating": 6.5,
+      "name": "Sin City: A Dame to Kill For",
+      "tvdb_id": 189
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000501",
+      "tvdb_id": 11477,
+      "name": "Ray Liotta"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0099685",
+      "votes": 1186782,
+      "rating": 8.7,
+      "name": "Goodfellas",
+      "tvdb_id": 769
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000582",
+      "tvdb_id": 4517,
+      "name": "Joe Pesci"
+    }
+  ]
+}

--- a/puzzles/2024-02-17.json
+++ b/puzzles/2024-02-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 24045,
+  "target_tvdb_id": 3392,
+  "source_imdb_id": "nm0330687",
+  "target_imdb_id": "nm0000140",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0645785",
+      "tvdb_id": 56120,
+      "name": "Yuji Okumoto"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119174",
+      "votes": 407687,
+      "rating": 7.7,
+      "name": "The Game",
+      "tvdb_id": 2649
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
+    }
+  ]
+}

--- a/puzzles/2024-02-18.json
+++ b/puzzles/2024-02-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 8891,
+  "target_tvdb_id": 3131,
+  "source_imdb_id": "nm0000237",
+  "target_imdb_id": "nm0000104",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000237",
+      "tvdb_id": 8891,
+      "name": "John Travolta"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000114",
+      "tvdb_id": 884,
+      "name": "Steve Buscemi"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0112851",
+      "votes": 190570,
+      "rating": 7.1,
+      "name": "Desperado",
+      "tvdb_id": 8068
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000104",
+      "tvdb_id": 3131,
+      "name": "Antonio Banderas"
+    }
+  ]
+}

--- a/puzzles/2024-02-19.json
+++ b/puzzles/2024-02-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6885,
+  "target_tvdb_id": 3223,
+  "source_imdb_id": "nm0000234",
+  "target_imdb_id": "nm0000375",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000234",
+      "tvdb_id": 6885,
+      "name": "Charlize Theron"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1446714",
+      "votes": 620211,
+      "rating": 7.0,
+      "name": "Prometheus",
+      "tvdb_id": 70981
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0636426",
+      "tvdb_id": 87722,
+      "name": "Noomi Rapace"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1515091",
+      "votes": 464766,
+      "rating": 7.4,
+      "name": "Sherlock Holmes: A Game of Shadows",
+      "tvdb_id": 58574
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000375",
+      "tvdb_id": 3223,
+      "name": "Robert Downey Jr."
+    }
+  ]
+}

--- a/puzzles/2024-02-20.json
+++ b/puzzles/2024-02-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 996701,
+  "target_tvdb_id": 21657,
+  "source_imdb_id": "nm1886602",
+  "target_imdb_id": "nm0267812",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1886602",
+      "tvdb_id": 996701,
+      "name": "Miles Teller"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2582802",
+      "votes": 898359,
+      "rating": 8.5,
+      "name": "Whiplash",
+      "tvdb_id": 244786
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1193138",
+      "votes": 341335,
+      "rating": 7.4,
+      "name": "Up in the Air",
+      "tvdb_id": 22947
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0267812",
+      "tvdb_id": 21657,
+      "name": "Vera Farmiga"
+    }
+  ]
+}

--- a/puzzles/2024-02-21.json
+++ b/puzzles/2024-02-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 27578,
+  "target_tvdb_id": 504,
+  "source_imdb_id": "nm0680983",
+  "target_imdb_id": "nm0000209",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0680983",
+      "tvdb_id": 27578,
+      "name": "Elliot Page"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm4798882",
+      "tvdb_id": null,
+      "name": "Brad Jacobowitz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0111161",
+      "votes": 2734155,
+      "rating": 9.3,
+      "name": "The Shawshank Redemption",
+      "tvdb_id": 278
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000209",
+      "tvdb_id": 504,
+      "name": "Tim Robbins"
+    }
+  ]
+}

--- a/puzzles/2024-02-22.json
+++ b/puzzles/2024-02-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 190,
+  "target_tvdb_id": 2219,
+  "source_imdb_id": "nm0000142",
+  "target_imdb_id": "nm0001497",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000142",
+      "tvdb_id": 190,
+      "name": "Clint Eastwood"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0105695",
+      "votes": 419562,
+      "rating": 8.2,
+      "name": "Unforgiven",
+      "tvdb_id": 33
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0430829",
+      "tvdb_id": 21380,
+      "name": "Larry Joshua"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001497",
+      "tvdb_id": 2219,
+      "name": "Tobey Maguire"
+    }
+  ]
+}

--- a/puzzles/2024-02-23.json
+++ b/puzzles/2024-02-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5081,
+  "target_tvdb_id": 131,
+  "source_imdb_id": "nm1289434",
+  "target_imdb_id": "nm0350453",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1289434",
+      "tvdb_id": 5081,
+      "name": "Emily Blunt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1631867",
+      "votes": 696689,
+      "rating": 7.9,
+      "name": "Edge of Tomorrow",
+      "tvdb_id": 137113
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000200",
+      "tvdb_id": 2053,
+      "name": "Bill Paxton"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2872718",
+      "votes": 566709,
+      "rating": 7.8,
+      "name": "Nightcrawler",
+      "tvdb_id": 242582
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0350453",
+      "tvdb_id": 131,
+      "name": "Jake Gyllenhaal"
+    }
+  ]
+}

--- a/puzzles/2024-02-24.json
+++ b/puzzles/2024-02-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1136406,
+  "target_tvdb_id": 192,
+  "source_imdb_id": "nm4043618",
+  "target_imdb_id": "nm0000151",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm4043618",
+      "tvdb_id": 1136406,
+      "name": "Tom Holland"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2250912",
+      "votes": 676089,
+      "rating": 7.4,
+      "name": "Spider-Man: Homecoming",
+      "tvdb_id": 315635
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000569",
+      "tvdb_id": 12052,
+      "name": "Gwyneth Paltrow"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114369",
+      "votes": 1690351,
+      "rating": 8.6,
+      "name": "Se7en",
+      "tvdb_id": 807
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    }
+  ]
+}

--- a/puzzles/2024-02-25.json
+++ b/puzzles/2024-02-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1328,
+  "target_tvdb_id": 776,
+  "source_imdb_id": "nm0000276",
+  "target_imdb_id": "nm0000552",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000276",
+      "tvdb_id": 1328,
+      "name": "Sean Astin"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0343660",
+      "votes": 365092,
+      "rating": 6.8,
+      "name": "50 First Dates",
+      "tvdb_id": 1824
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748973",
+      "tvdb_id": 52792,
+      "name": "Maya Rudolph"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0413267",
+      "votes": 317481,
+      "rating": 6.1,
+      "name": "Shrek the Third",
+      "tvdb_id": 810
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000552",
+      "tvdb_id": 776,
+      "name": "Eddie Murphy"
+    }
+  ]
+}

--- a/puzzles/2024-02-26.json
+++ b/puzzles/2024-02-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 10959,
+  "target_tvdb_id": 368,
+  "source_imdb_id": "nm0479471",
+  "target_imdb_id": "nm0000702",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0479471",
+      "tvdb_id": 10959,
+      "name": "Shia LaBeouf"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1212450",
+      "votes": 246541,
+      "rating": 7.2,
+      "name": "Lawless",
+      "tvdb_id": 82633
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0362766",
+      "tvdb_id": 2524,
+      "name": "Tom Hardy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1596350",
+      "votes": 190062,
+      "rating": 6.3,
+      "name": "This Means War",
+      "tvdb_id": 59962
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000702",
+      "tvdb_id": 368,
+      "name": "Reese Witherspoon"
+    }
+  ]
+}

--- a/puzzles/2024-02-27.json
+++ b/puzzles/2024-02-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1037,
+  "target_tvdb_id": 1640,
+  "source_imdb_id": "nm0000172",
+  "target_imdb_id": "nm0001745",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000172",
+      "tvdb_id": 1037,
+      "name": "Harvey Keitel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0289765",
+      "votes": 280472,
+      "rating": 7.2,
+      "name": "Red Dragon",
+      "tvdb_id": 9533
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000164",
+      "tvdb_id": 4173,
+      "name": "Anthony Hopkins"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0800369",
+      "votes": 864977,
+      "rating": 7.0,
+      "name": "Thor",
+      "tvdb_id": 10195
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001745",
+      "tvdb_id": 1640,
+      "name": "Stellan Skarsg\u00e5rd"
+    }
+  ]
+}

--- a/puzzles/2024-02-28.json
+++ b/puzzles/2024-02-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17604,
+  "target_tvdb_id": 3,
+  "source_imdb_id": "nm0719637",
+  "target_imdb_id": "nm0000148",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0719637",
+      "tvdb_id": 17604,
+      "name": "Jeremy Renner"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2381249",
+      "votes": 382513,
+      "rating": 7.4,
+      "name": "Mission: Impossible - Rogue Nation",
+      "tvdb_id": 177677
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0670408",
+      "tvdb_id": 11108,
+      "name": "Simon Pegg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2488496",
+      "votes": 944891,
+      "rating": 7.8,
+      "name": "Star Wars: Episode VII - The Force Awakens",
+      "tvdb_id": 140607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
+    }
+  ]
+}

--- a/puzzles/2024-02-29.json
+++ b/puzzles/2024-02-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6383,
+  "target_tvdb_id": 23659,
+  "source_imdb_id": "nm0001173",
+  "target_imdb_id": "nm0002071",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001173",
+      "tvdb_id": 6383,
+      "name": "Aaron Eckhart"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0350454",
+      "tvdb_id": 1579,
+      "name": "Maggie Gyllenhaal"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0420223",
+      "votes": 232126,
+      "rating": 7.5,
+      "name": "Stranger Than Fiction",
+      "tvdb_id": 1262
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0002071",
+      "tvdb_id": 23659,
+      "name": "Will Ferrell"
+    }
+  ]
+}

--- a/puzzles/2024-03-01.json
+++ b/puzzles/2024-03-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3896,
+  "target_tvdb_id": 529,
+  "source_imdb_id": "nm0000553",
+  "target_imdb_id": "nm0001602",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000553",
+      "tvdb_id": 3896,
+      "name": "Liam Neeson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0372784",
+      "votes": 1497833,
+      "rating": 8.2,
+      "name": "Batman Begins",
+      "tvdb_id": 272
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0095478",
+      "tvdb_id": 534,
+      "name": "Mark Boone Junior"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0209144",
+      "votes": 1259603,
+      "rating": 8.4,
+      "name": "Memento",
+      "tvdb_id": 77
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001602",
+      "tvdb_id": 529,
+      "name": "Guy Pearce"
+    }
+  ]
+}

--- a/puzzles/2024-03-02.json
+++ b/puzzles/2024-03-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 8784,
+  "target_tvdb_id": 12073,
+  "source_imdb_id": "nm0185819",
+  "target_imdb_id": "nm0000196",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0185819",
+      "tvdb_id": 8784,
+      "name": "Daniel Craig"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2379713",
+      "votes": 449737,
+      "rating": 6.8,
+      "name": "Spectre",
+      "tvdb_id": 206647
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0910607",
+      "tvdb_id": 27319,
+      "name": "Christoph Waltz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000196",
+      "tvdb_id": 12073,
+      "name": "Mike Myers"
+    }
+  ]
+}

--- a/puzzles/2024-03-03.json
+++ b/puzzles/2024-03-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 27319,
+  "target_tvdb_id": 4783,
+  "source_imdb_id": "nm0910607",
+  "target_imdb_id": "nm0000554",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0910607",
+      "tvdb_id": 27319,
+      "name": "Christoph Waltz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0107290",
+      "votes": 1010271,
+      "rating": 8.2,
+      "name": "Jurassic Park",
+      "tvdb_id": 329
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000554",
+      "tvdb_id": 4783,
+      "name": "Sam Neill"
+    }
+  ]
+}

--- a/puzzles/2024-03-04.json
+++ b/puzzles/2024-03-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6856,
+  "target_tvdb_id": 6968,
+  "source_imdb_id": "nm0000621",
+  "target_imdb_id": "nm0413168",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000621",
+      "tvdb_id": 6856,
+      "name": "Kurt Russell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0116253",
+      "votes": 59474,
+      "rating": 6.5,
+      "name": "Executive Decision",
+      "tvdb_id": 2320
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000932",
+      "tvdb_id": 4587,
+      "name": "Halle Berry"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0376994",
+      "votes": 525602,
+      "rating": 6.6,
+      "name": "X-Men: The Last Stand",
+      "tvdb_id": 36668
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0413168",
+      "tvdb_id": 6968,
+      "name": "Hugh Jackman"
+    }
+  ]
+}

--- a/puzzles/2024-03-05.json
+++ b/puzzles/2024-03-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 8289,
+  "target_tvdb_id": 9642,
+  "source_imdb_id": "nm0001082",
+  "target_imdb_id": "nm0000179",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001082",
+      "tvdb_id": 8289,
+      "name": "Billy Crudup"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1895587",
+      "votes": 480584,
+      "rating": 8.1,
+      "name": "Spotlight",
+      "tvdb_id": 314365
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1046097",
+      "tvdb_id": 53714,
+      "name": "Rachel McAdams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0988045",
+      "votes": 646635,
+      "rating": 7.6,
+      "name": "Sherlock Holmes",
+      "tvdb_id": 10528
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000179",
+      "tvdb_id": 9642,
+      "name": "Jude Law"
+    }
+  ]
+}

--- a/puzzles/2024-03-06.json
+++ b/puzzles/2024-03-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2227,
+  "target_tvdb_id": 5081,
+  "source_imdb_id": "nm0000173",
+  "target_imdb_id": "nm1289434",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000173",
+      "tvdb_id": 2227,
+      "name": "Nicole Kidman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120663",
+      "votes": 353030,
+      "rating": 7.5,
+      "name": "Eyes Wide Shut",
+      "tvdb_id": 345
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000129",
+      "tvdb_id": 500,
+      "name": "Tom Cruise"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1631867",
+      "votes": 696689,
+      "rating": 7.9,
+      "name": "Edge of Tomorrow",
+      "tvdb_id": 137113
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1289434",
+      "tvdb_id": 5081,
+      "name": "Emily Blunt"
+    }
+  ]
+}

--- a/puzzles/2024-03-07.json
+++ b/puzzles/2024-03-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3036,
+  "target_tvdb_id": 1532,
+  "source_imdb_id": "nm0000131",
+  "target_imdb_id": "nm0000195",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000131",
+      "tvdb_id": 3036,
+      "name": "John Cusack"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1190080",
+      "votes": 385247,
+      "rating": 5.8,
+      "name": "2012",
+      "tvdb_id": 14161
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000437",
+      "tvdb_id": 57755,
+      "name": "Woody Harrelson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1156398",
+      "votes": 593204,
+      "rating": 7.6,
+      "name": "Zombieland",
+      "tvdb_id": 19908
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000195",
+      "tvdb_id": 1532,
+      "name": "Bill Murray"
+    }
+  ]
+}

--- a/puzzles/2024-03-08.json
+++ b/puzzles/2024-03-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 880,
+  "target_tvdb_id": 12073,
+  "source_imdb_id": "nm0000255",
+  "target_imdb_id": "nm0000196",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2140479",
+      "votes": 303579,
+      "rating": 7.3,
+      "name": "The Accountant",
+      "tvdb_id": 302946
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001475",
+      "tvdb_id": 12074,
+      "name": "John Lithgow"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0126029",
+      "votes": 697051,
+      "rating": 7.9,
+      "name": "Shrek",
+      "tvdb_id": 808
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000196",
+      "tvdb_id": 12073,
+      "name": "Mike Myers"
+    }
+  ]
+}

--- a/puzzles/2024-03-09.json
+++ b/puzzles/2024-03-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 290,
+  "target_tvdb_id": 884,
+  "source_imdb_id": "nm0001626",
+  "target_imdb_id": "nm0000114",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001626",
+      "tvdb_id": 290,
+      "name": "Christopher Plummer"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1049413",
+      "votes": 1065269,
+      "rating": 8.3,
+      "name": "Up",
+      "tvdb_id": 14160
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0677037",
+      "tvdb_id": 10,
+      "name": "Bob Peterson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0198781",
+      "votes": 928601,
+      "rating": 8.1,
+      "name": "Monsters, Inc.",
+      "tvdb_id": 585
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000114",
+      "tvdb_id": 884,
+      "name": "Steve Buscemi"
+    }
+  ]
+}

--- a/puzzles/2024-03-10.json
+++ b/puzzles/2024-03-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 139,
+  "target_tvdb_id": 12835,
+  "source_imdb_id": "nm0000235",
+  "target_imdb_id": "nm0004874",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000235",
+      "tvdb_id": 139,
+      "name": "Uma Thurman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0295701",
+      "votes": 182564,
+      "rating": 5.8,
+      "name": "xXx",
+      "tvdb_id": 7451
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004874",
+      "tvdb_id": 12835,
+      "name": "Vin Diesel"
+    }
+  ]
+}

--- a/puzzles/2024-03-11.json
+++ b/puzzles/2024-03-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 74568,
+  "target_tvdb_id": 139,
+  "source_imdb_id": "nm1165110",
+  "target_imdb_id": "nm0000235",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1165110",
+      "tvdb_id": 74568,
+      "name": "Chris Hemsworth"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2395427",
+      "votes": 881783,
+      "rating": 7.3,
+      "name": "Avengers: Age of Ultron",
+      "tvdb_id": 99861
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000235",
+      "tvdb_id": 139,
+      "name": "Uma Thurman"
+    }
+  ]
+}

--- a/puzzles/2024-03-12.json
+++ b/puzzles/2024-03-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6383,
+  "target_tvdb_id": 18277,
+  "source_imdb_id": "nm0001173",
+  "target_imdb_id": "nm0000113",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001173",
+      "tvdb_id": 6383,
+      "name": "Aaron Eckhart"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0468569",
+      "votes": 2707279,
+      "rating": 9.0,
+      "name": "The Dark Knight",
+      "tvdb_id": 155
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0212346",
+      "votes": 218001,
+      "rating": 6.3,
+      "name": "Miss Congeniality",
+      "tvdb_id": 1493
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000113",
+      "tvdb_id": 18277,
+      "name": "Sandra Bullock"
+    }
+  ]
+}

--- a/puzzles/2024-03-13.json
+++ b/puzzles/2024-03-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 70851,
+  "target_tvdb_id": 6885,
+  "source_imdb_id": "nm0085312",
+  "target_imdb_id": "nm0000234",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0085312",
+      "tvdb_id": 70851,
+      "name": "Jack Black"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0307453",
+      "votes": 189400,
+      "rating": 6.0,
+      "name": "Shark Tale",
+      "tvdb_id": 10555
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000226",
+      "tvdb_id": 2888,
+      "name": "Will Smith"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0448157",
+      "votes": 493621,
+      "rating": 6.4,
+      "name": "Hancock",
+      "tvdb_id": 8960
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000234",
+      "tvdb_id": 6885,
+      "name": "Charlize Theron"
+    }
+  ]
+}

--- a/puzzles/2024-03-14.json
+++ b/puzzles/2024-03-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3895,
+  "target_tvdb_id": 2157,
+  "source_imdb_id": "nm0000323",
+  "target_imdb_id": "nm0000245",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0482571",
+      "votes": 1359502,
+      "rating": 8.5,
+      "name": "The Prestige",
+      "tvdb_id": 1124
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0413168",
+      "tvdb_id": 6968,
+      "name": "Hugh Jackman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0366548",
+      "votes": 191970,
+      "rating": 6.4,
+      "name": "Happy Feet",
+      "tvdb_id": 9836
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000245",
+      "tvdb_id": 2157,
+      "name": "Robin Williams"
+    }
+  ]
+}

--- a/puzzles/2024-03-15.json
+++ b/puzzles/2024-03-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17051,
+  "target_tvdb_id": 1640,
+  "source_imdb_id": "nm0290556",
+  "target_imdb_id": "nm0001745",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0290556",
+      "tvdb_id": 17051,
+      "name": "James Franco"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0316654",
+      "votes": 669481,
+      "rating": 7.4,
+      "name": "Spider-Man 2",
+      "tvdb_id": 558
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000379",
+      "tvdb_id": 205,
+      "name": "Kirsten Dunst"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1527186",
+      "votes": 187583,
+      "rating": 7.1,
+      "name": "Melancholia",
+      "tvdb_id": 62215
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001745",
+      "tvdb_id": 1640,
+      "name": "Stellan Skarsg\u00e5rd"
+    }
+  ]
+}

--- a/puzzles/2024-03-16.json
+++ b/puzzles/2024-03-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 85,
+  "target_tvdb_id": 287,
+  "source_imdb_id": "nm0000136",
+  "target_imdb_id": "nm0000093",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000136",
+      "tvdb_id": 85,
+      "name": "Johnny Depp"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0408236",
+      "votes": 375346,
+      "rating": 7.3,
+      "name": "Sweeney Todd: The Demon Barber of Fleet Street",
+      "tvdb_id": 13885
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000307",
+      "tvdb_id": 1283,
+      "name": "Helena Bonham Carter"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0137523",
+      "votes": 2176824,
+      "rating": 8.8,
+      "name": "Fight Club",
+      "tvdb_id": 550
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    }
+  ]
+}

--- a/puzzles/2024-03-17.json
+++ b/puzzles/2024-03-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 6856,
+  "target_tvdb_id": 5293,
+  "source_imdb_id": "nm0000621",
+  "target_imdb_id": "nm0000353",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000621",
+      "tvdb_id": 6856,
+      "name": "Kurt Russell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3460252",
+      "votes": 620842,
+      "rating": 7.8,
+      "name": "The Hateful Eight",
+      "tvdb_id": 273248
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0329774",
+      "votes": 71929,
+      "rating": 4.4,
+      "name": "xXx: State of the Union",
+      "tvdb_id": 11679
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    }
+  ]
+}

--- a/puzzles/2024-03-18.json
+++ b/puzzles/2024-03-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 204,
+  "target_tvdb_id": 17604,
+  "source_imdb_id": "nm0000701",
+  "target_imdb_id": "nm0719637",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000701",
+      "tvdb_id": 204,
+      "name": "Kate Winslet"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338013",
+      "votes": 1027917,
+      "rating": 8.3,
+      "name": "Eternal Sunshine of the Spotless Mind",
+      "tvdb_id": 38
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0848228",
+      "votes": 1411541,
+      "rating": 8.0,
+      "name": "The Avengers",
+      "tvdb_id": 24428
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0719637",
+      "tvdb_id": 17604,
+      "name": "Jeremy Renner"
+    }
+  ]
+}

--- a/puzzles/2024-03-19.json
+++ b/puzzles/2024-03-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 62,
+  "target_tvdb_id": 3895,
+  "source_imdb_id": "nm0000246",
+  "target_imdb_id": "nm0000323",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000246",
+      "tvdb_id": 62,
+      "name": "Bruce Willis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1276104",
+      "votes": 585768,
+      "rating": 7.4,
+      "name": "Looper",
+      "tvdb_id": 59967
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    }
+  ]
+}

--- a/puzzles/2024-03-20.json
+++ b/puzzles/2024-03-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4491,
+  "target_tvdb_id": 1532,
+  "source_imdb_id": "nm0000098",
+  "target_imdb_id": "nm0000195",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000098",
+      "tvdb_id": 4491,
+      "name": "Jennifer Aniston"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0822832",
+      "votes": 162029,
+      "rating": 7.0,
+      "name": "Marley & Me",
+      "tvdb_id": 14306
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005562",
+      "tvdb_id": 887,
+      "name": "Owen Wilson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0362270",
+      "votes": 202406,
+      "rating": 7.2,
+      "name": "The Life Aquatic with Steve Zissou",
+      "tvdb_id": 421
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000195",
+      "tvdb_id": 1532,
+      "name": "Bill Murray"
+    }
+  ]
+}

--- a/puzzles/2024-03-21.json
+++ b/puzzles/2024-03-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 64,
+  "target_tvdb_id": 3087,
+  "source_imdb_id": "nm0000198",
+  "target_imdb_id": "nm0000380",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000198",
+      "tvdb_id": 64,
+      "name": "Gary Oldman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110413",
+      "votes": 1184637,
+      "rating": 8.5,
+      "name": "L\u00e9on: The Professional",
+      "tvdb_id": 101
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000732",
+      "tvdb_id": 1004,
+      "name": "Danny Aiello"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0071562",
+      "votes": 1296165,
+      "rating": 9.0,
+      "name": "The Godfather Part II",
+      "tvdb_id": 240
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000380",
+      "tvdb_id": 3087,
+      "name": "Robert Duvall"
+    }
+  ]
+}

--- a/puzzles/2024-03-22.json
+++ b/puzzles/2024-03-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 368,
+  "target_tvdb_id": 24045,
+  "source_imdb_id": "nm0000702",
+  "target_imdb_id": "nm0330687",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000702",
+      "tvdb_id": 368,
+      "name": "Reese Witherspoon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0144084",
+      "votes": 651517,
+      "rating": 7.6,
+      "name": "American Psycho",
+      "tvdb_id": 1359
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1345836",
+      "votes": 1735537,
+      "rating": 8.4,
+      "name": "The Dark Knight Rises",
+      "tvdb_id": 49026
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
+    }
+  ]
+}

--- a/puzzles/2024-03-23.json
+++ b/puzzles/2024-03-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 70851,
+  "target_tvdb_id": 9560,
+  "source_imdb_id": "nm0085312",
+  "target_imdb_id": "nm0000995",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0085312",
+      "tvdb_id": 70851,
+      "name": "Jack Black"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0942385",
+      "votes": 427941,
+      "rating": 7.1,
+      "name": "Tropic Thunder",
+      "tvdb_id": 7446
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000190",
+      "tvdb_id": 10297,
+      "name": "Matthew McConaughey"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0816692",
+      "votes": 1897864,
+      "rating": 8.6,
+      "name": "Interstellar",
+      "tvdb_id": 157336
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000995",
+      "tvdb_id": 9560,
+      "name": "Ellen Burstyn"
+    }
+  ]
+}

--- a/puzzles/2024-03-24.json
+++ b/puzzles/2024-03-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2283,
+  "target_tvdb_id": 62064,
+  "source_imdb_id": "nm0001804",
+  "target_imdb_id": "nm1517976",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001804",
+      "tvdb_id": 2283,
+      "name": "Stanley Tucci"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0362227",
+      "votes": 471100,
+      "rating": 7.4,
+      "name": "The Terminal",
+      "tvdb_id": 594
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0796366",
+      "votes": 609483,
+      "rating": 7.9,
+      "name": "Star Trek",
+      "tvdb_id": 13475
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1517976",
+      "tvdb_id": 62064,
+      "name": "Chris Pine"
+    }
+  ]
+}

--- a/puzzles/2024-03-25.json
+++ b/puzzles/2024-03-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 976,
+  "target_tvdb_id": 8691,
+  "source_imdb_id": "nm0005458",
+  "target_imdb_id": "nm0757855",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005458",
+      "tvdb_id": 976,
+      "name": "Jason Statham"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2820852",
+      "votes": 397640,
+      "rating": 7.1,
+      "name": "Furious 7",
+      "tvdb_id": 168259
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004874",
+      "tvdb_id": 12835,
+      "name": "Vin Diesel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2015381",
+      "votes": 1202667,
+      "rating": 8.0,
+      "name": "Guardians of the Galaxy",
+      "tvdb_id": 118340
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0757855",
+      "tvdb_id": 8691,
+      "name": "Zoe Saldana"
+    }
+  ]
+}

--- a/puzzles/2024-03-26.json
+++ b/puzzles/2024-03-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 116,
+  "target_tvdb_id": 3895,
+  "source_imdb_id": "nm0461136",
+  "target_imdb_id": "nm0000323",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0461136",
+      "tvdb_id": 116,
+      "name": "Keira Knightley"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120915",
+      "votes": 821707,
+      "rating": 6.5,
+      "name": "Star Wars: Episode I - The Phantom Menace",
+      "tvdb_id": 1893
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000553",
+      "tvdb_id": 3896,
+      "name": "Liam Neeson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0372784",
+      "votes": 1497833,
+      "rating": 8.2,
+      "name": "Batman Begins",
+      "tvdb_id": 272
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000323",
+      "tvdb_id": 3895,
+      "name": "Michael Caine"
+    }
+  ]
+}

--- a/puzzles/2024-03-27.json
+++ b/puzzles/2024-03-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2231,
+  "target_tvdb_id": 1003,
+  "source_imdb_id": "nm0000168",
+  "target_imdb_id": "nm0000606",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0121766",
+      "votes": 808568,
+      "rating": 7.6,
+      "name": "Star Wars: Episode III - Revenge of the Sith",
+      "tvdb_id": 1895
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000204",
+      "tvdb_id": 524,
+      "name": "Natalie Portman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110413",
+      "votes": 1184637,
+      "rating": 8.5,
+      "name": "L\u00e9on: The Professional",
+      "tvdb_id": 101
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000606",
+      "tvdb_id": 1003,
+      "name": "Jean Reno"
+    }
+  ]
+}

--- a/puzzles/2024-03-28.json
+++ b/puzzles/2024-03-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4937,
+  "target_tvdb_id": 1327,
+  "source_imdb_id": "nm0000681",
+  "target_imdb_id": "nm0005212",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000681",
+      "tvdb_id": 4937,
+      "name": "Vince Vaughn"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2119532",
+      "votes": 546213,
+      "rating": 8.1,
+      "name": "Hacksaw Ridge",
+      "tvdb_id": 324786
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0915989",
+      "tvdb_id": 1331,
+      "name": "Hugo Weaving"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0903624",
+      "votes": 842123,
+      "rating": 7.8,
+      "name": "The Hobbit: An Unexpected Journey",
+      "tvdb_id": 49051
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0005212",
+      "tvdb_id": 1327,
+      "name": "Ian McKellen"
+    }
+  ]
+}

--- a/puzzles/2024-03-29.json
+++ b/puzzles/2024-03-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 4517,
+  "target_tvdb_id": 290,
+  "source_imdb_id": "nm0000582",
+  "target_imdb_id": "nm0001626",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000582",
+      "tvdb_id": 4517,
+      "name": "Joe Pesci"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1302006",
+      "votes": 401561,
+      "rating": 7.8,
+      "name": "The Irishman",
+      "tvdb_id": 398978
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0140352",
+      "votes": 174514,
+      "rating": 7.8,
+      "name": "The Insider",
+      "tvdb_id": 9008
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001626",
+      "tvdb_id": 290,
+      "name": "Christopher Plummer"
+    }
+  ]
+}

--- a/puzzles/2024-03-30.json
+++ b/puzzles/2024-03-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17288,
+  "target_tvdb_id": 1204,
+  "source_imdb_id": "nm1055413",
+  "target_imdb_id": "nm0000210",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0349903",
+      "votes": 399386,
+      "rating": 6.5,
+      "name": "Ocean's Twelve",
+      "tvdb_id": 163
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000210",
+      "tvdb_id": 1204,
+      "name": "Julia Roberts"
+    }
+  ]
+}

--- a/puzzles/2024-03-31.json
+++ b/puzzles/2024-03-31.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3061,
+  "target_tvdb_id": 2176,
+  "source_imdb_id": "nm0000191",
+  "target_imdb_id": "nm0000169",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0117951",
+      "votes": 699227,
+      "rating": 8.1,
+      "name": "Trainspotting",
+      "tvdb_id": 627
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0531808",
+      "tvdb_id": 9015,
+      "name": "Kelly Macdonald"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0477348",
+      "votes": 997439,
+      "rating": 8.2,
+      "name": "No Country for Old Men",
+      "tvdb_id": 6977
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
+    }
+  ]
+}

--- a/puzzles/2024-04-01.json
+++ b/puzzles/2024-04-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 193,
+  "target_tvdb_id": 134,
+  "source_imdb_id": "nm0000432",
+  "target_imdb_id": "nm0004937",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000432",
+      "tvdb_id": 193,
+      "name": "Gene Hackman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114214",
+      "votes": 97961,
+      "rating": 6.5,
+      "name": "The Quick and the Dead",
+      "tvdb_id": 12106
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    }
+  ]
+}

--- a/puzzles/2024-04-02.json
+++ b/puzzles/2024-04-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17288,
+  "target_tvdb_id": 134,
+  "source_imdb_id": "nm1055413",
+  "target_imdb_id": "nm0004937",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0361748",
+      "votes": 1485428,
+      "rating": 8.3,
+      "name": "Inglourious Basterds",
+      "tvdb_id": 16869
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0910607",
+      "tvdb_id": 27319,
+      "name": "Christoph Waltz"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    }
+  ]
+}

--- a/puzzles/2024-04-03.json
+++ b/puzzles/2024-04-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3084,
+  "target_tvdb_id": 93210,
+  "source_imdb_id": "nm0000008",
+  "target_imdb_id": "nm1727304",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000008",
+      "tvdb_id": 3084,
+      "name": "Marlon Brando"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0078788",
+      "votes": 680101,
+      "rating": 8.5,
+      "name": "Apocalypse Now",
+      "tvdb_id": 28
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000148",
+      "tvdb_id": 3,
+      "name": "Harrison Ford"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2488496",
+      "votes": 944891,
+      "rating": 7.8,
+      "name": "Star Wars: Episode VII - The Force Awakens",
+      "tvdb_id": 140607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1727304",
+      "tvdb_id": 93210,
+      "name": "Domhnall Gleeson"
+    }
+  ]
+}

--- a/puzzles/2024-04-04.json
+++ b/puzzles/2024-04-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3223,
+  "target_tvdb_id": 173431,
+  "source_imdb_id": "nm0000375",
+  "target_imdb_id": "nm0021600",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000375",
+      "tvdb_id": 3223,
+      "name": "Robert Downey Jr."
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1300854",
+      "votes": 866335,
+      "rating": 7.1,
+      "name": "Iron Man 3",
+      "tvdb_id": 68721
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1019674",
+      "tvdb_id": 1366,
+      "name": "Sala Baker"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0167261",
+      "votes": 1697780,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Two Towers",
+      "tvdb_id": 121
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0021600",
+      "tvdb_id": 173431,
+      "name": "Bruce Allpress"
+    }
+  ]
+}

--- a/puzzles/2024-04-05.json
+++ b/puzzles/2024-04-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1892,
+  "target_tvdb_id": 3967,
+  "source_imdb_id": "nm0000354",
+  "target_imdb_id": "nm0000295",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0407887",
+      "votes": 1351191,
+      "rating": 8.5,
+      "name": "The Departed",
+      "tvdb_id": 1422
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338751",
+      "votes": 370181,
+      "rating": 7.5,
+      "name": "The Aviator",
+      "tvdb_id": 2567
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000295",
+      "tvdb_id": 3967,
+      "name": "Kate Beckinsale"
+    }
+  ]
+}

--- a/puzzles/2024-04-06.json
+++ b/puzzles/2024-04-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 22226,
+  "target_tvdb_id": 24045,
+  "source_imdb_id": "nm0748620",
+  "target_imdb_id": "nm0330687",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0117509",
+      "votes": 235119,
+      "rating": 6.7,
+      "name": "Romeo + Juliet",
+      "tvdb_id": 454
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000138",
+      "tvdb_id": 6193,
+      "name": "Leonardo DiCaprio"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1375666",
+      "votes": 2403153,
+      "rating": 8.8,
+      "name": "Inception",
+      "tvdb_id": 27205
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0330687",
+      "tvdb_id": 24045,
+      "name": "Joseph Gordon-Levitt"
+    }
+  ]
+}

--- a/puzzles/2024-04-07.json
+++ b/puzzles/2024-04-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 934,
+  "target_tvdb_id": 380,
+  "source_imdb_id": "nm0000128",
+  "target_imdb_id": "nm0000134",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0140352",
+      "votes": 174514,
+      "rating": 7.8,
+      "name": "The Insider",
+      "tvdb_id": 9008
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0071562",
+      "votes": 1296165,
+      "rating": 9.0,
+      "name": "The Godfather Part II",
+      "tvdb_id": 240
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000134",
+      "tvdb_id": 380,
+      "name": "Robert De Niro"
+    }
+  ]
+}

--- a/puzzles/2024-04-08.json
+++ b/puzzles/2024-04-08.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3061,
+  "target_tvdb_id": 9642,
+  "source_imdb_id": "nm0000191",
+  "target_imdb_id": "nm0000179",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000191",
+      "tvdb_id": 3061,
+      "name": "Ewan McGregor"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0121766",
+      "votes": 808568,
+      "rating": 7.6,
+      "name": "Star Wars: Episode III - Revenge of the Sith",
+      "tvdb_id": 1895
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000204",
+      "tvdb_id": 524,
+      "name": "Natalie Portman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0376541",
+      "votes": 226513,
+      "rating": 7.2,
+      "name": "Closer",
+      "tvdb_id": 2288
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000179",
+      "tvdb_id": 9642,
+      "name": "Jude Law"
+    }
+  ]
+}

--- a/puzzles/2024-04-09.json
+++ b/puzzles/2024-04-09.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 449,
+  "target_tvdb_id": 287,
+  "source_imdb_id": "nm0059431",
+  "target_imdb_id": "nm0000093",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0405159",
+      "votes": 698263,
+      "rating": 8.1,
+      "name": "Million Dollar Baby",
+      "tvdb_id": 70
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0114369",
+      "votes": 1690351,
+      "rating": 8.6,
+      "name": "Se7en",
+      "tvdb_id": 807
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    }
+  ]
+}

--- a/puzzles/2024-04-10.json
+++ b/puzzles/2024-04-10.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5472,
+  "target_tvdb_id": 19292,
+  "source_imdb_id": "nm0000147",
+  "target_imdb_id": "nm0001191",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000147",
+      "tvdb_id": 5472,
+      "name": "Colin Firth"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1504320",
+      "votes": 690511,
+      "rating": 8.0,
+      "name": "The King's Speech",
+      "tvdb_id": 45269
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001602",
+      "tvdb_id": 529,
+      "name": "Guy Pearce"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0960731",
+      "votes": 97927,
+      "rating": 6.0,
+      "name": "Bedtime Stories",
+      "tvdb_id": 10202
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001191",
+      "tvdb_id": 19292,
+      "name": "Adam Sandler"
+    }
+  ]
+}

--- a/puzzles/2024-04-11.json
+++ b/puzzles/2024-04-11.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 9273,
+  "target_tvdb_id": 500,
+  "source_imdb_id": "nm0010736",
+  "target_imdb_id": "nm0000129",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0010736",
+      "tvdb_id": 9273,
+      "name": "Amy Adams"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2543164",
+      "votes": 715446,
+      "rating": 7.9,
+      "name": "Arrival",
+      "tvdb_id": 329865
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0719637",
+      "tvdb_id": 17604,
+      "name": "Jeremy Renner"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2381249",
+      "votes": 382513,
+      "rating": 7.4,
+      "name": "Mission: Impossible - Rogue Nation",
+      "tvdb_id": 177677
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000129",
+      "tvdb_id": 500,
+      "name": "Tom Cruise"
+    }
+  ]
+}

--- a/puzzles/2024-04-12.json
+++ b/puzzles/2024-04-12.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5469,
+  "target_tvdb_id": 85,
+  "source_imdb_id": "nm0000146",
+  "target_imdb_id": "nm0000136",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000146",
+      "tvdb_id": 5469,
+      "name": "Ralph Fiennes"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1201607",
+      "votes": 897033,
+      "rating": 8.1,
+      "name": "Harry Potter and the Deathly Hallows: Part 2",
+      "tvdb_id": 12445
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0002091",
+      "tvdb_id": 5658,
+      "name": "Michael Gambon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0162661",
+      "votes": 368969,
+      "rating": 7.3,
+      "name": "Sleepy Hollow",
+      "tvdb_id": 2668
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000136",
+      "tvdb_id": 85,
+      "name": "Johnny Depp"
+    }
+  ]
+}

--- a/puzzles/2024-04-13.json
+++ b/puzzles/2024-04-13.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 16828,
+  "target_tvdb_id": 4,
+  "source_imdb_id": "nm0262635",
+  "target_imdb_id": "nm0000402",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0262635",
+      "tvdb_id": 16828,
+      "name": "Chris Evans"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1843866",
+      "votes": 862951,
+      "rating": 7.8,
+      "name": "Captain America: The Winter Soldier",
+      "tvdb_id": 100402
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2527338",
+      "votes": 465144,
+      "rating": 6.5,
+      "name": "Star Wars: Episode IX - The Rise of Skywalker",
+      "tvdb_id": 181812
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000402",
+      "tvdb_id": 4,
+      "name": "Carrie Fisher"
+    }
+  ]
+}

--- a/puzzles/2024-04-14.json
+++ b/puzzles/2024-04-14.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 3490,
+  "target_tvdb_id": 449,
+  "source_imdb_id": "nm0004778",
+  "target_imdb_id": "nm0059431",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004778",
+      "tvdb_id": 3490,
+      "name": "Adrien Brody"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2278388",
+      "votes": 834412,
+      "rating": 8.1,
+      "name": "The Grand Budapest Hotel",
+      "tvdb_id": 120467
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000719",
+      "tvdb_id": 1164,
+      "name": "F. Murray Abraham"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2386490",
+      "votes": 137040,
+      "rating": 7.4,
+      "name": "How to Train Your Dragon: The Hidden World",
+      "tvdb_id": 166428
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0059431",
+      "tvdb_id": 449,
+      "name": "Jay Baruchel"
+    }
+  ]
+}

--- a/puzzles/2024-04-15.json
+++ b/puzzles/2024-04-15.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 19274,
+  "target_tvdb_id": 72129,
+  "source_imdb_id": "nm0736622",
+  "target_imdb_id": "nm2225369",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0736622",
+      "tvdb_id": 19274,
+      "name": "Seth Rogen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0829482",
+      "votes": 597604,
+      "rating": 7.6,
+      "name": "Superbad",
+      "tvdb_id": 8363
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt11286314",
+      "votes": 555062,
+      "rating": 7.2,
+      "name": "Don't Look Up",
+      "tvdb_id": 646380
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm2225369",
+      "tvdb_id": 72129,
+      "name": "Jennifer Lawrence"
+    }
+  ]
+}

--- a/puzzles/2024-04-16.json
+++ b/puzzles/2024-04-16.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 73968,
+  "target_tvdb_id": 10980,
+  "source_imdb_id": "nm0147147",
+  "target_imdb_id": "nm0705356",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2975590",
+      "votes": 710461,
+      "rating": 6.4,
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0251986",
+      "tvdb_id": 44735,
+      "name": "Jesse Eisenberg"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3110958",
+      "votes": 301677,
+      "rating": 6.4,
+      "name": "Now You See Me 2",
+      "tvdb_id": 291805
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0705356",
+      "tvdb_id": 10980,
+      "name": "Daniel Radcliffe"
+    }
+  ]
+}

--- a/puzzles/2024-04-17.json
+++ b/puzzles/2024-04-17.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 48,
+  "target_tvdb_id": 51329,
+  "source_imdb_id": "nm0000293",
+  "target_imdb_id": "nm0177896",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000293",
+      "tvdb_id": 48,
+      "name": "Sean Bean"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0238380",
+      "votes": 337643,
+      "rating": 7.3,
+      "name": "Equilibrium",
+      "tvdb_id": 7299
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000288",
+      "tvdb_id": 3894,
+      "name": "Christian Bale"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1800241",
+      "votes": 487634,
+      "rating": 7.2,
+      "name": "American Hustle",
+      "tvdb_id": 168672
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0177896",
+      "tvdb_id": 51329,
+      "name": "Bradley Cooper"
+    }
+  ]
+}

--- a/puzzles/2024-04-18.json
+++ b/puzzles/2024-04-18.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 73968,
+  "target_tvdb_id": 6161,
+  "source_imdb_id": "nm0147147",
+  "target_imdb_id": "nm0000124",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0770828",
+      "votes": 784138,
+      "rating": 7.1,
+      "name": "Man of Steel",
+      "tvdb_id": 49521
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0268978",
+      "votes": 947632,
+      "rating": 8.2,
+      "name": "A Beautiful Mind",
+      "tvdb_id": 453
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000124",
+      "tvdb_id": 6161,
+      "name": "Jennifer Connelly"
+    }
+  ]
+}

--- a/puzzles/2024-04-19.json
+++ b/puzzles/2024-04-19.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 17051,
+  "target_tvdb_id": 17178,
+  "source_imdb_id": "nm0290556",
+  "target_imdb_id": "nm0933940",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0290556",
+      "tvdb_id": 17051,
+      "name": "James Franco"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000353",
+      "tvdb_id": 5293,
+      "name": "Willem Dafoe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1477834",
+      "votes": 488838,
+      "rating": 6.8,
+      "name": "Aquaman",
+      "tvdb_id": 297802
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0933940",
+      "tvdb_id": 17178,
+      "name": "Patrick Wilson"
+    }
+  ]
+}

--- a/puzzles/2024-04-20.json
+++ b/puzzles/2024-04-20.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1333,
+  "target_tvdb_id": 1158,
+  "source_imdb_id": "nm0785227",
+  "target_imdb_id": "nm0000199",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0785227",
+      "tvdb_id": 1333,
+      "name": "Andy Serkis"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120737",
+      "votes": 1909585,
+      "rating": 8.8,
+      "name": "The Lord of the Rings: The Fellowship of the Ring",
+      "tvdb_id": 120
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001557",
+      "tvdb_id": 110,
+      "name": "Viggo Mortensen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0106519",
+      "votes": 223761,
+      "rating": 7.9,
+      "name": "Carlito's Way",
+      "tvdb_id": 6075
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    }
+  ]
+}

--- a/puzzles/2024-04-21.json
+++ b/puzzles/2024-04-21.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 5530,
+  "target_tvdb_id": 22226,
+  "source_imdb_id": "nm0564215",
+  "target_imdb_id": "nm0748620",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0564215",
+      "tvdb_id": 5530,
+      "name": "James McAvoy"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt3385516",
+      "votes": 444498,
+      "rating": 6.9,
+      "name": "X-Men: Apocalypse",
+      "tvdb_id": 246655
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0498278",
+      "tvdb_id": 7624,
+      "name": "Stan Lee"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0478970",
+      "votes": 689185,
+      "rating": 7.3,
+      "name": "Ant-Man",
+      "tvdb_id": 102899
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0748620",
+      "tvdb_id": 22226,
+      "name": "Paul Rudd"
+    }
+  ]
+}

--- a/puzzles/2024-04-22.json
+++ b/puzzles/2024-04-22.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 514,
+  "target_tvdb_id": 3392,
+  "source_imdb_id": "nm0000197",
+  "target_imdb_id": "nm0000140",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000197",
+      "tvdb_id": 514,
+      "name": "Jack Nicholson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0825232",
+      "votes": 251064,
+      "rating": 7.4,
+      "name": "The Bucket List",
+      "tvdb_id": 7350
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000151",
+      "tvdb_id": 192,
+      "name": "Morgan Freeman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1204975",
+      "votes": 134231,
+      "rating": 6.6,
+      "name": "Last Vegas",
+      "tvdb_id": 137093
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000140",
+      "tvdb_id": 3392,
+      "name": "Michael Douglas"
+    }
+  ]
+}

--- a/puzzles/2024-04-23.json
+++ b/puzzles/2024-04-23.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 118,
+  "target_tvdb_id": 7447,
+  "source_imdb_id": "nm0001691",
+  "target_imdb_id": "nm0000285",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001691",
+      "tvdb_id": 118,
+      "name": "Geoffrey Rush"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0325980",
+      "votes": 1149544,
+      "rating": 8.1,
+      "name": "Pirates of the Caribbean: The Curse of the Black Pearl",
+      "tvdb_id": 22
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0089217",
+      "tvdb_id": 114,
+      "name": "Orlando Bloom"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0368709",
+      "votes": 71360,
+      "rating": 6.3,
+      "name": "Elizabethtown",
+      "tvdb_id": 9621
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000285",
+      "tvdb_id": 7447,
+      "name": "Alec Baldwin"
+    }
+  ]
+}

--- a/puzzles/2024-04-24.json
+++ b/puzzles/2024-04-24.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 19274,
+  "target_tvdb_id": 8289,
+  "source_imdb_id": "nm0736622",
+  "target_imdb_id": "nm0001082",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0736622",
+      "tvdb_id": 19274,
+      "name": "Seth Rogen"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0910936",
+      "votes": 346971,
+      "rating": 6.9,
+      "name": "Pineapple Express",
+      "tvdb_id": 10189
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1144419",
+      "tvdb_id": 62862,
+      "name": "Danny McBride"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2316204",
+      "votes": 288740,
+      "rating": 6.4,
+      "name": "Alien: Covenant",
+      "tvdb_id": 126889
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001082",
+      "tvdb_id": 8289,
+      "name": "Billy Crudup"
+    }
+  ]
+}

--- a/puzzles/2024-04-25.json
+++ b/puzzles/2024-04-25.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1158,
+  "target_tvdb_id": 73968,
+  "source_imdb_id": "nm0000199",
+  "target_imdb_id": "nm0147147",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000199",
+      "tvdb_id": 1158,
+      "name": "Al Pacino"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0140352",
+      "votes": 174514,
+      "rating": 7.8,
+      "name": "The Insider",
+      "tvdb_id": 9008
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000128",
+      "tvdb_id": 934,
+      "name": "Russell Crowe"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0770828",
+      "votes": 784138,
+      "rating": 7.1,
+      "name": "Man of Steel",
+      "tvdb_id": 49521
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
+    }
+  ]
+}

--- a/puzzles/2024-04-26.json
+++ b/puzzles/2024-04-26.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 38673,
+  "target_tvdb_id": 4491,
+  "source_imdb_id": "nm1475594",
+  "target_imdb_id": "nm0000098",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm1475594",
+      "tvdb_id": 38673,
+      "name": "Channing Tatum"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1232829",
+      "votes": 573036,
+      "rating": 7.2,
+      "name": "21 Jump Street",
+      "tvdb_id": 64688
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0644406",
+      "tvdb_id": 17039,
+      "name": "Nick Offerman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1723121",
+      "votes": 461840,
+      "rating": 7.0,
+      "name": "We're the Millers",
+      "tvdb_id": 138832
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000098",
+      "tvdb_id": 4491,
+      "name": "Jennifer Aniston"
+    }
+  ]
+}

--- a/puzzles/2024-04-27.json
+++ b/puzzles/2024-04-27.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 529,
+  "target_tvdb_id": 2178,
+  "source_imdb_id": "nm0001602",
+  "target_imdb_id": "nm0001845",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001602",
+      "tvdb_id": 529,
+      "name": "Guy Pearce"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0887912",
+      "votes": 460137,
+      "rating": 7.5,
+      "name": "The Hurt Locker",
+      "tvdb_id": 12162
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0719637",
+      "tvdb_id": 17604,
+      "name": "Jeremy Renner"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2543164",
+      "votes": 715446,
+      "rating": 7.9,
+      "name": "Arrival",
+      "tvdb_id": 329865
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001845",
+      "tvdb_id": 2178,
+      "name": "Forest Whitaker"
+    }
+  ]
+}

--- a/puzzles/2024-04-28.json
+++ b/puzzles/2024-04-28.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2888,
+  "target_tvdb_id": 287,
+  "source_imdb_id": "nm0000226",
+  "target_imdb_id": "nm0000093",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000226",
+      "tvdb_id": 2888,
+      "name": "Will Smith"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119654",
+      "votes": 582276,
+      "rating": 7.3,
+      "name": "Men in Black",
+      "tvdb_id": 607
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2935510",
+      "votes": 244986,
+      "rating": 6.5,
+      "name": "Ad Astra",
+      "tvdb_id": 419704
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    }
+  ]
+}

--- a/puzzles/2024-04-29.json
+++ b/puzzles/2024-04-29.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 139,
+  "target_tvdb_id": 2176,
+  "source_imdb_id": "nm0000235",
+  "target_imdb_id": "nm0000169",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000235",
+      "tvdb_id": 139,
+      "name": "Uma Thurman"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0110912",
+      "votes": 2101050,
+      "rating": 8.9,
+      "name": "Pulp Fiction",
+      "tvdb_id": 680
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000168",
+      "tvdb_id": 2231,
+      "name": "Samuel L. Jackson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0458339",
+      "votes": 861338,
+      "rating": 6.9,
+      "name": "Captain America: The First Avenger",
+      "tvdb_id": 1771
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000169",
+      "tvdb_id": 2176,
+      "name": "Tommy Lee Jones"
+    }
+  ]
+}

--- a/puzzles/2024-04-30.json
+++ b/puzzles/2024-04-30.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 205,
+  "target_tvdb_id": 8167,
+  "source_imdb_id": "nm0000379",
+  "target_imdb_id": "nm0908094",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000379",
+      "tvdb_id": 205,
+      "name": "Kirsten Dunst"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0145487",
+      "votes": 834989,
+      "rating": 7.4,
+      "name": "Spider-Man",
+      "tvdb_id": 557
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001497",
+      "tvdb_id": 2219,
+      "name": "Tobey Maguire"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0120789",
+      "votes": 132060,
+      "rating": 7.5,
+      "name": "Pleasantville",
+      "tvdb_id": 2657
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0908094",
+      "tvdb_id": 8167,
+      "name": "Paul Walker"
+    }
+  ]
+}

--- a/puzzles/2024-05-01.json
+++ b/puzzles/2024-05-01.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 500,
+  "target_tvdb_id": 21007,
+  "source_imdb_id": "nm0000129",
+  "target_imdb_id": "nm1706767",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000129",
+      "tvdb_id": 500,
+      "name": "Tom Cruise"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0369339",
+      "votes": 414730,
+      "rating": 7.5,
+      "name": "Collateral",
+      "tvdb_id": 1538
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0004937",
+      "tvdb_id": 134,
+      "name": "Jamie Foxx"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1853728",
+      "votes": 1592500,
+      "rating": 8.4,
+      "name": "Django Unchained",
+      "tvdb_id": 68718
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1706767",
+      "tvdb_id": 21007,
+      "name": "Jonah Hill"
+    }
+  ]
+}

--- a/puzzles/2024-05-02.json
+++ b/puzzles/2024-05-02.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 18918,
+  "target_tvdb_id": 30614,
+  "source_imdb_id": "nm0425005",
+  "target_imdb_id": "nm0331516",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0425005",
+      "tvdb_id": 18918,
+      "name": "Dwayne Johnson"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0425061",
+      "votes": 222123,
+      "rating": 6.5,
+      "name": "Get Smart",
+      "tvdb_id": 11665
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0136797",
+      "tvdb_id": 4495,
+      "name": "Steve Carell"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1570728",
+      "votes": 532097,
+      "rating": 7.4,
+      "name": "Crazy, Stupid, Love.",
+      "tvdb_id": 50646
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0331516",
+      "tvdb_id": 30614,
+      "name": "Ryan Gosling"
+    }
+  ]
+}

--- a/puzzles/2024-05-03.json
+++ b/puzzles/2024-05-03.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1640,
+  "target_tvdb_id": 287,
+  "source_imdb_id": "nm0001745",
+  "target_imdb_id": "nm0000093",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001745",
+      "tvdb_id": 1640,
+      "name": "Stellan Skarsg\u00e5rd"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0119217",
+      "votes": 998916,
+      "rating": 8.3,
+      "name": "Good Will Hunting",
+      "tvdb_id": 489
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000354",
+      "tvdb_id": 1892,
+      "name": "Matt Damon"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0496806",
+      "votes": 354950,
+      "rating": 6.9,
+      "name": "Ocean's Thirteen",
+      "tvdb_id": 298
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000093",
+      "tvdb_id": 287,
+      "name": "Brad Pitt"
+    }
+  ]
+}

--- a/puzzles/2024-05-04.json
+++ b/puzzles/2024-05-04.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 2975,
+  "target_tvdb_id": 6383,
+  "source_imdb_id": "nm0000401",
+  "target_imdb_id": "nm0001173",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000401",
+      "tvdb_id": 2975,
+      "name": "Laurence Fishburne"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2975590",
+      "votes": 710461,
+      "rating": 6.4,
+      "name": "Batman v Superman: Dawn of Justice",
+      "tvdb_id": 209112
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000255",
+      "tvdb_id": 880,
+      "name": "Ben Affleck"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0338337",
+      "votes": 110626,
+      "rating": 6.3,
+      "name": "Paycheck",
+      "tvdb_id": 9620
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0001173",
+      "tvdb_id": 6383,
+      "name": "Aaron Eckhart"
+    }
+  ]
+}

--- a/puzzles/2024-05-05.json
+++ b/puzzles/2024-05-05.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 73968,
+  "target_tvdb_id": 27578,
+  "source_imdb_id": "nm0147147",
+  "target_imdb_id": "nm0680983",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0147147",
+      "tvdb_id": 73968,
+      "name": "Henry Cavill"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0974015",
+      "votes": 461723,
+      "rating": 6.1,
+      "name": "Justice League",
+      "tvdb_id": 141052
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0799777",
+      "tvdb_id": 18999,
+      "name": "J.K. Simmons"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0467406",
+      "votes": 531704,
+      "rating": 7.5,
+      "name": "Juno",
+      "tvdb_id": 7326
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0680983",
+      "tvdb_id": 27578,
+      "name": "Elliot Page"
+    }
+  ]
+}

--- a/puzzles/2024-05-06.json
+++ b/puzzles/2024-05-06.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 1461,
+  "target_tvdb_id": 103,
+  "source_imdb_id": "nm0000123",
+  "target_imdb_id": "nm0749263",
+  "min_moves_to_solve": 3,
+  "source_birthday": true,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000123",
+      "tvdb_id": 1461,
+      "name": "George Clooney"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt0496806",
+      "votes": 354950,
+      "rating": 6.9,
+      "name": "Ocean's Thirteen",
+      "tvdb_id": 298
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000332",
+      "tvdb_id": 1896,
+      "name": "Don Cheadle"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt2395427",
+      "votes": 881783,
+      "rating": 7.3,
+      "name": "Avengers: Age of Ultron",
+      "tvdb_id": 99861
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0749263",
+      "tvdb_id": 103,
+      "name": "Mark Ruffalo"
+    }
+  ]
+}

--- a/puzzles/2024-05-07.json
+++ b/puzzles/2024-05-07.json
@@ -1,0 +1,44 @@
+{
+  "source_tvdb_id": 37917,
+  "target_tvdb_id": 17288,
+  "source_imdb_id": "nm0829576",
+  "target_imdb_id": "nm1055413",
+  "min_moves_to_solve": 3,
+  "source_birthday": false,
+  "best_solution": [
+    {
+      "type": "Actor",
+      "imdb_id": "nm0829576",
+      "tvdb_id": 37917,
+      "name": "Kristen Stewart"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1735898",
+      "votes": 294509,
+      "rating": 6.1,
+      "name": "Snow White and the Huntsman",
+      "tvdb_id": 58595
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm0000234",
+      "tvdb_id": 6885,
+      "name": "Charlize Theron"
+    },
+    {
+      "type": "Film",
+      "imdb_id": "tt1446714",
+      "votes": 620211,
+      "rating": 7.0,
+      "name": "Prometheus",
+      "tvdb_id": 70981
+    },
+    {
+      "type": "Actor",
+      "imdb_id": "nm1055413",
+      "tvdb_id": 17288,
+      "name": "Michael Fassbender"
+    }
+  ]
+}


### PR DESCRIPTION
3 main changes:
- Added new puzzles for the next 365 days
- Puzzles now prioritize birthday actors if the actors are sufficiently high profile (Puzzles start with Birthday actors in ~40% of cases)
- Added `source_birthday` Boolean attribute to the puzzle JSON files to indicate when it's the starting actor's Birthday.
